### PR TITLE
Using settings.json instead of plugin.settings.json

### DIFF
--- a/MHWItemBoxTracker/Config/ConfigLoader.cs
+++ b/MHWItemBoxTracker/Config/ConfigLoader.cs
@@ -4,14 +4,15 @@ namespace MHWItemBoxTracker.Config
 {
     class ConfigLoader
     {
+        private static string settings = "settings.json";
         public static ItemBoxTrackerConfig loadConfig()
         {
-            return PathFinder.loadJson<ItemBoxTrackerConfig>("plugin.settings.json");
+            return PathFinder.loadJson<ItemBoxTrackerConfig>(settings);
         }
 
         public static void saveConfig(ItemBoxTrackerConfig config)
         {
-            PathFinder.saveJson("plugin.settings.json", config);
+            PathFinder.saveJson(settings, config);
         }
     }
 }

--- a/MHWItemBoxTracker/Config/ItemBoxTrackerConfig.cs
+++ b/MHWItemBoxTracker/Config/ItemBoxTrackerConfig.cs
@@ -5,7 +5,7 @@ using HunterPie.Plugins;
 
 namespace MHWItemBoxTracker.Config
 {
-    public class ItemBoxTrackerConfig : PluginSettings
+    public class ItemBoxTrackerConfig
     {
 
         [DisplayName("Items to Track")]

--- a/MHWItemBoxTracker/GUI/ItemBoxTracker.xaml.cs
+++ b/MHWItemBoxTracker/GUI/ItemBoxTracker.xaml.cs
@@ -66,7 +66,7 @@ namespace MHWItemBoxTracker.GUI
 
                     Left = config.Overlay.Position[0] + UserSettings.PlayerConfig.Overlay.Position[0];
                     Top = config.Overlay.Position[1] + UserSettings.PlayerConfig.Overlay.Position[1];
-                    WidgetActive = config?.IsEnabled ?? true;
+                    WidgetActive = config.Overlay.Enabled;
                     Opacity = config.Overlay.Opacity;
                 }
                 base.ApplySettings();


### PR DESCRIPTION
# Bugfix
<!--
Please try to limit your pull request to one type, submit multiple pull requests if needed.
Copy/Keep the appropriate heading out of this comment:
# Bugfix
# Feature
# Code style update (formatting, renaming)
# Refactoring (no functional changes, no api changes)
# Build related changes
# Documentation content changes

# Other
> (please describe):
-->

## Pull request checklist

<!-- Checkboxes can be checked like this: [x] -->

Please check if your PR fulfills the following requirements:
- [x] ~~Tests for the changes have been added (for bug fixes / features)~~
<!-- - [ ] Pre-commmit hook is enabled (`git config --get core.hooksPath` is _.githooks_) -->
- [x] ~~Docs have been reviewed and added / updated if needed (for bug fixes / features)~~

## What does this implement/fix? Explain your changes.
By using _settings.json_ instead of _plugin.settings.json_, plugin has it's own settings file that HunterPie won't touch.

## Is this related to any currently open issues?
<!--
Mention the issue(s) this is related to. For more info, see:
https://docs.gitlab.com/ee/user/project/issues/managing_issues.html#closing-issues-automatically
Related to means only some progress was made. The others will close the issue once it's merged/
 -->

- #13
- #14

## What tests cover this change?
N/A

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
