### PR TITLE
Don't setup dotnet core because it breaks msbuild...

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -33,8 +33,8 @@ jobs:
         cp .github/NuGet.Config .
         msbuild -m /t:Restore
 
-    - name: Execute unit tests
-      run: dotnet test
+    # - name: Execute unit tests
+    #   run: dotnet test
 
     # if I had tests, I probably wouldn't need to build...
     - name: Build the apps

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -20,11 +20,6 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
 
-    - name: Install .NET Core
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 5.0.x
-
     - name: Setup MSBuild.exe
       uses: microsoft/setup-msbuild@v1.0.2
 


### PR DESCRIPTION
# Build related changes

## Pull request checklist

<!-- Checkboxes can be checked like this: [x] -->

Please check if your PR fulfills the following requirements:
- [x] ~~Tests for the changes have been added (for bug fixes / features)~~
<!-- - [ ] Pre-commmit hook is enabled (`git config --get core.hooksPath` is _.githooks_) -->
- [x] ~~Docs have been reviewed and added / updated if needed (for bug fixes / features)~~

## What does this implement/fix? Explain your changes.

Fixes broken PR job by not setting up or using dotnet cli. If you run msbuild after setting up dotnet, the build step fails with the error below.

## Is this related to any currently open issues?

No.

## What tests cover this change?

PR job succeeds

## Other information

https://github.com/Stuff-Mods/MHWItemBoxTracker/runs/1803161024?check_suite_focus=true
```
Build FAILED.

       "D:\a\MHWItemBoxTracker\MHWItemBoxTracker\ItemBoxTracker.sln" (default target) (1) ->
       "D:\a\MHWItemBoxTracker\MHWItemBoxTracker\ItemBoxTracker\ItemBoxTracker.csproj" (default target) (2) ->
       (ResolveNuGetPackageAssets target) -> 
         C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Microsoft\NuGet\16.0\Microsoft.NuGet.targets(198,5): error : Your project file doesn't list 'win' as a "RuntimeIdentifier". You should add 'win' to the "RuntimeIdentifiers" property in your project file and then re-run NuGet restore. [D:\a\MHWItemBoxTracker\MHWItemBoxTracker\ItemBoxTracker\ItemBoxTracker.csproj]
```
