### PR TITLE
Add settings tab to Hunter Pie

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+# editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+
+# indentation
+indent_size = 2
+indent_style = space
+
+# new lines
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+# no trim final new lines :(

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,5 +4,12 @@
   "omnisharp.disableMSBuildDiagnosticWarning": true,
   "omnisharp.enableImportCompletion": true,
   "omnisharp.organizeImportsOnFormat": true,
-  "omnisharp.enableRoslynAnalyzers": true
+  "omnisharp.enableRoslynAnalyzers": true,
+  "files.exclude": {
+    "**/.vs": true,
+    "**/*.dll": true,
+    "**/bin": true,
+    "**/obj": true,
+    "*/Properties/": true
+  }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+  "xml.format.splitAttributes": true,
+  "files.trimFinalNewlines": true,
+  "omnisharp.disableMSBuildDiagnosticWarning": true,
+  "omnisharp.enableImportCompletion": true,
+  "omnisharp.organizeImportsOnFormat": true,
+  "omnisharp.enableRoslynAnalyzers": true
+}

--- a/ItemBoxTracker/Config/DeprecatedItemBoxTrackerConfig.cs
+++ b/ItemBoxTracker/Config/DeprecatedItemBoxTrackerConfig.cs
@@ -1,14 +1,10 @@
 ﻿using System.Collections.Generic;
 using System.ComponentModel;
-using System.ComponentModel.DataAnnotations;
-using HunterPie.Plugins;
 
-namespace MHWItemBoxTracker.Config
-{
-    public class DeprecatedItemBoxTrackerConfig
-    {
-        [DisplayName("Items to Track")]
-        [Description("You can find item IDs here: https://github.com/Ezekial711/MonsterHunterWorldModding/wiki/Item-IDs")]
-        public List<ItemConfig> Tracking { get; set; } = new List<ItemConfig>();
-    }
+namespace MHWItemBoxTracker.Config {
+  public class DeprecatedItemBoxTrackerConfig {
+    [DisplayName("Items to Track")]
+    [Description("You can find item IDs here: https://github.com/Ezekial711/MonsterHunterWorldModding/wiki/Item-IDs")]
+    public List<ItemConfig> Tracking { get; set; } = new List<ItemConfig>();
+  }
 }

--- a/ItemBoxTracker/Config/ItemBoxTrackerConfig.cs
+++ b/ItemBoxTracker/Config/ItemBoxTrackerConfig.cs
@@ -1,22 +1,17 @@
-﻿using System.Collections.Generic;
-using System.ComponentModel;
-using System.ComponentModel.DataAnnotations;
-using HunterPie.Plugins;
+﻿using System.ComponentModel;
 
-namespace MHWItemBoxTracker.Config
-{
-    public class ItemBoxTrackerConfig
-    {
-        [DisplayName("Track Always")]
-        [Description("Items to track everywhere")]
-        public TrackingTabConfig Always { get; set; } = new TrackingTabConfig();
-        
-        [DisplayName("Track in Village")]
-        [Description("Items to track only in the village/gathering hub")]
-        public TrackingTabConfig Village { get; set; } = new TrackingTabConfig();
-        
-        [DisplayName("Track in Quest")]
-        [Description("Items to track during a quest/expedition/guiding lands")]
-        public TrackingTabConfig Quest { get; set; } = new TrackingTabConfig();
-    }
+namespace MHWItemBoxTracker.Config {
+  public class ItemBoxTrackerConfig {
+    [DisplayName("Track Always")]
+    [Description("Items to track everywhere")]
+    public TrackingTabConfig Always { get; set; } = new TrackingTabConfig();
+
+    [DisplayName("Track in Village")]
+    [Description("Items to track only in the village/gathering hub")]
+    public TrackingTabConfig Village { get; set; } = new TrackingTabConfig();
+
+    [DisplayName("Track in Quest")]
+    [Description("Items to track during a quest/expedition/guiding lands")]
+    public TrackingTabConfig Quest { get; set; } = new TrackingTabConfig();
+  }
 }

--- a/ItemBoxTracker/Config/ItemBoxWidgetSettings.cs
+++ b/ItemBoxTracker/Config/ItemBoxWidgetSettings.cs
@@ -1,12 +1,10 @@
-namespace MHWItemBoxTracker.Config
-{
-    public class ItemBoxWidgetSettings : HunterPie.Core.Settings.IWidgetSettings
-    {
-        public bool Initialize { get; set; } = true;
-        public bool Enabled { get; set; } = true;
-        public int[] Position { get; set; } = new int[] { 20, 20 };
-        public float Opacity { get; set; } = 1;
-        public double Scale { get; set; } = 1;
-        public bool StreamerMode { get; set; } = false;
-    }
+namespace MHWItemBoxTracker.Config {
+  public class ItemBoxWidgetSettings : HunterPie.Core.Settings.IWidgetSettings {
+    public bool Initialize { get; set; } = true;
+    public bool Enabled { get; set; } = true;
+    public int[] Position { get; set; } = new int[] { 20, 20 };
+    public float Opacity { get; set; } = 1;
+    public double Scale { get; set; } = 1;
+    public bool StreamerMode { get; set; } = false;
+  }
 }

--- a/ItemBoxTracker/Config/ItemConfig.cs
+++ b/ItemBoxTracker/Config/ItemConfig.cs
@@ -1,13 +1,11 @@
 ﻿using System.ComponentModel.DataAnnotations;
 
-namespace MHWItemBoxTracker.Config
-{
-    public class ItemConfig
-    {
-        public string Name { get; set; }
-        [Required]
-        public int ItemId { get; set; }
-        [Required]
-        public int Amount { get; set; }
-    }
+namespace MHWItemBoxTracker.Config {
+  public class ItemConfig {
+    public string Name { get; set; }
+    [Required]
+    public int ItemId { get; set; }
+    [Required]
+    public int Amount { get; set; }
+  }
 }

--- a/ItemBoxTracker/Config/TrackingTabConfig.cs
+++ b/ItemBoxTracker/Config/TrackingTabConfig.cs
@@ -1,26 +1,22 @@
 ﻿using System.Collections.Generic;
 using System.ComponentModel;
-using System.ComponentModel.DataAnnotations;
-using HunterPie.Plugins;
 
-namespace MHWItemBoxTracker.Config
-{
-    public class TrackingTabConfig
-    {
-        [DisplayName("Track items in pouch")]
-        [Description("Enable to count items in your pouch on the progress bars")]
-        public bool TrackPouch { get; set; } = false;
-        
-        [DisplayName("Track items in box")]
-        [Description("Enable to count items in your box on the progress bars")]
-        public bool TrackBox { get; set; } = true;
-        
-        [DisplayName("Track craftable items")]
-        [Description("Enable to count items that can be crafted on the progress bars")]
-        public bool TrackCraftable { get; set; } = false;
+namespace MHWItemBoxTracker.Config {
+  public class TrackingTabConfig {
+    [DisplayName("Track items in pouch")]
+    [Description("Enable to count items in your pouch on the progress bars")]
+    public bool TrackPouch { get; set; } = false;
 
-        [DisplayName("Items to Track")]
-        [Description("You can find item IDs here: https://github.com/Ezekial711/MonsterHunterWorldModding/wiki/Item-IDs")]
-        public List<ItemConfig> Tracking { get; set; } = new List<ItemConfig>();
-    }
+    [DisplayName("Track items in box")]
+    [Description("Enable to count items in your box on the progress bars")]
+    public bool TrackBox { get; set; } = true;
+
+    [DisplayName("Track craftable items")]
+    [Description("Enable to count items that can be crafted on the progress bars")]
+    public bool TrackCraftable { get; set; } = false;
+
+    [DisplayName("Items to Track")]
+    [Description("You can find item IDs here: https://github.com/Ezekial711/MonsterHunterWorldModding/wiki/Item-IDs")]
+    public List<ItemConfig> Tracking { get; set; } = new List<ItemConfig>();
+  }
 }

--- a/ItemBoxTracker/Controller/ItemBoxTracker.cs
+++ b/ItemBoxTracker/Controller/ItemBoxTracker.cs
@@ -1,14 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using HunterPie.Core;
 using HunterPie.GUI;
-using HunterPie.Plugins;
 using MHWItemBoxTracker.Config;
 using MHWItemBoxTracker.Service;
-using static MHWItemBoxTracker.Main;
 using static MHWItemBoxTracker.Utils.Dispatcher;
 
 namespace MHWItemBoxTracker.Controller {

--- a/ItemBoxTracker/Controller/ItemBoxTracker.cs
+++ b/ItemBoxTracker/Controller/ItemBoxTracker.cs
@@ -3,87 +3,77 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Windows;
 using HunterPie.Core;
 using HunterPie.GUI;
-using MHWItemBoxTracker.Config;
-using MHWItemBoxTracker.Utils;
 using HunterPie.Plugins;
+using MHWItemBoxTracker.Config;
 using static MHWItemBoxTracker.Main;
 using static MHWItemBoxTracker.Utils.Dispatcher;
 
-namespace MHWItemBoxTracker.Controller
-{
-    class ItemBoxTracker
-    {
-        private Player player { get; }
-        private GUI.ItemBoxTracker gui;
-        private static SemaphoreSlim locke = new SemaphoreSlim(1,1);
+namespace MHWItemBoxTracker.Controller {
+  class ItemBoxTracker {
+    private Player player { get; }
+    private GUI.ItemBoxTracker gui;
+    private static readonly SemaphoreSlim locke = new(1, 1);
 
-        public ItemBoxTracker(Player player)
-        {
-            this.player = player;
-            Dispatch(() =>
-            {
-                gui = new GUI.ItemBoxTracker();
-                Overlay.RegisterWidget(gui);
-            });
-        }
-
-        public void loadItemBox(object source = null, EventArgs e = null)
-        {
-            if (!player.InHarvestZone) return;
-            Dispatch(async () => {
-                var config = (await loadSettings()).Always;
-
-                var items = config.Tracking;
-                var box = player.ItemBox;
-                var ids = items.Select(ic => ic.ItemId).ToHashSet();
-
-                var itemsHeld = box.FindItemsInBox(ids);
-                var itemBoxRows = new List<GUI.ItemBoxRow>();
-                foreach (ItemConfig item in items)
-                {
-                    int amountHeld = 0;
-                    itemsHeld.TryGetValue(item.ItemId, out amountHeld);
-
-                    itemBoxRows.Add(new GUI.ItemBoxRow
-                    {
-                        name = item.Name,
-                        ratio = $"{amountHeld}/{item.Amount}",
-                        progress = 100.0 * amountHeld / item.Amount,
-                    });
-                }
-                gui.setItemsToDisplay(itemBoxRows);
-            });
-        }
-
-        public void unloadItemBox(object source = null, EventArgs e = null)
-        {
-            Dispatch(() => gui.setItemsToDisplay(new List<GUI.ItemBoxRow>()));
-        }
-
-        public void unregister() {
-            Dispatch(() => Overlay.UnregisterWidget(gui));
-        }
-
-        private async Task<ItemBoxTrackerConfig> loadSettings() {
-          await locke.WaitAsync();
-          try {
-            // TODO: use Settings.xaml.cs
-            var config = await Plugin.LoadJson<ItemBoxTrackerConfig>("settings.json");
-
-            // Not writing a comparer just for this...
-            var oldConfig = await Plugin.LoadJson<DeprecatedItemBoxTrackerConfig>("settings.json");
-            if (oldConfig.Tracking.Count > 0) {
-              config.Always.Tracking = oldConfig.Tracking.ToList();
-              await Plugin.SaveJson<ItemBoxTrackerConfig>("settings.json", config);
-            }
-
-            return config;
-          } finally {
-            locke.Release();
-          }
-        }
+    public ItemBoxTracker(Player player) {
+      this.player = player;
+      Dispatch(() => {
+        gui = new GUI.ItemBoxTracker();
+        Overlay.RegisterWidget(gui);
+      });
     }
+
+    public void loadItemBox(object source = null, EventArgs e = null) {
+      if (!player.InHarvestZone) return;
+      Dispatch(async () => {
+        var config = (await loadSettings()).Always;
+
+        var items = config.Tracking;
+        var box = player.ItemBox;
+        var ids = items.Select(ic => ic.ItemId).ToHashSet();
+
+        var itemsHeld = box.FindItemsInBox(ids);
+        var itemBoxRows = new List<GUI.ItemBoxRow>();
+        foreach (ItemConfig item in items) {
+          itemsHeld.TryGetValue(item.ItemId, out int amountHeld);
+
+          itemBoxRows.Add(new GUI.ItemBoxRow {
+            name = item.Name,
+            ratio = $"{amountHeld}/{item.Amount}",
+            progress = 100.0 * amountHeld / item.Amount,
+          });
+        }
+        gui.setItemsToDisplay(itemBoxRows);
+      });
+    }
+
+    public void unloadItemBox(object source = null, EventArgs e = null) {
+      Dispatch(() => gui.setItemsToDisplay(new List<GUI.ItemBoxRow>()));
+    }
+
+    public void unregister() {
+      Dispatch(() => Overlay.UnregisterWidget(gui));
+    }
+
+    private async Task<ItemBoxTrackerConfig> loadSettings() {
+      await locke.WaitAsync();
+      try {
+        // TODO: use Settings.xaml.cs
+        var config = await Plugin.LoadJson<ItemBoxTrackerConfig>("settings.json");
+
+        // Not writing a comparer just for this...
+        var oldConfig = await Plugin.LoadJson<DeprecatedItemBoxTrackerConfig>("settings.json");
+        if (oldConfig.Tracking.Count > 0) {
+          config.Always.Tracking = oldConfig.Tracking.ToList();
+          await Plugin.SaveJson<ItemBoxTrackerConfig>("settings.json", config);
+        }
+
+        return config;
+      }
+      finally {
+        locke.Release();
+      }
+    }
+  }
 }

--- a/ItemBoxTracker/Converter/ItemIdToDescription.cs
+++ b/ItemBoxTracker/Converter/ItemIdToDescription.cs
@@ -1,0 +1,10 @@
+using HunterPie.Core.Native;
+using HunterPie.UI.Infrastructure.Converters;
+
+namespace MHWItemBoxTracker.Converter {
+  public class ItemIdToDescription : GenericValueConverter<int, string> {
+    public override string Convert(int value, object parameter) {
+      return GMD.GetItemDescriptionById(value);
+    }
+  }
+}

--- a/ItemBoxTracker/GUI/AutoSuggestBox.xaml
+++ b/ItemBoxTracker/GUI/AutoSuggestBox.xaml
@@ -1,0 +1,102 @@
+<UserControl
+    x:Class="MHWItemBoxTracker.GUI.AutoSuggestBox"
+    x:Name="AutoSuggest"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    mc:Ignorable="d"
+    Margin="10,0,10,5"
+    d:DesignWidth="200">
+  <UserControl.Resources>
+    <BooleanToVisibilityConverter x:Key="bool2Visibility" />
+  </UserControl.Resources>
+
+  <StackPanel DataContext="{Binding ElementName=AutoSuggest}">
+    <Border
+        BorderBrush="#FFABADB3"
+        BorderThickness="0 0 0 1"
+        Padding="5 0"
+        Background="{x:Null}"
+        Width="{Binding ActualWidth}"
+        Height="30">
+      <Grid VerticalAlignment="Center">
+        <Grid.ColumnDefinitions>
+          <ColumnDefinition Width="*" />
+          <ColumnDefinition Width="Auto" />
+        </Grid.ColumnDefinitions>
+
+        <TextBlock
+            Grid.Column='0'
+            Text="{Binding Placeholder}"
+            Foreground="#cc9E9D9D"
+            Visibility="{Binding Text.IsEmpty, ElementName=searchInput, Converter={StaticResource bool2Visibility}}" />
+        <TextBox
+            Grid.Column='0'
+            x:Name="searchInput"
+            BorderThickness="0"
+            Foreground="#ffbfbfbf"
+            TextChanged="TextChanged">
+          <TextBox.InputBindings>
+            <KeyBinding
+                Key="Return"
+                Command="{Binding OnEnter}"
+                CommandParameter="{Binding ElementName=searchInput, Path=Text}" />
+          </TextBox.InputBindings>
+        </TextBox>
+
+        <Border
+            Grid.Column='0'
+            CornerRadius="5"
+            Background="#1e5878"
+            Visibility="Collapsed"
+            x:Name="selectionCtrl">
+          <Grid>
+            <Grid.ColumnDefinitions>
+              <ColumnDefinition Width="*" />
+              <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+            <ContentControl
+                Grid.Column='0'
+                Content="{Binding Selection}"
+                ContentTemplate="{Binding ItemTemplate}" />
+            <TextBlock
+                Grid.Column='1'
+                Text="✘"
+                Foreground="#cc9E9D9D" />
+          </Grid>
+        </Border>
+
+        <TextBlock
+            Grid.Column='1'
+            Text="🔎"
+            Visibility="{Binding IsEnabled, ElementName=searchInput, Converter={StaticResource bool2Visibility}}"
+            Foreground="#cc9E9D9D" />
+      </Grid>
+    </Border>
+
+    <Popup
+        x:Name="suggestionsPopup"
+        Visibility="{Binding IsOpen, ElementName=suggestionsPopup, Converter={StaticResource bool2Visibility}}"
+        MinWidth="{Binding ActualWidth}"
+        MinHeight="30"
+        MaxHeight="150"
+        StaysOpen="False"
+        Placement="Bottom">
+      <Grid>
+        <ListBox
+            x:Name="suggestionsList"
+            Visibility="{Binding HasItems, ElementName=suggestionsList, Converter={StaticResource bool2Visibility}}"
+            SelectionChanged="SelectionChanged"
+            ItemTemplate="{Binding ItemTemplate}" />
+
+        <TextBlock
+            x:Name="noResults"
+            Text="No results..."
+            VerticalAlignment="Center"
+            Padding="5 0"
+            Foreground="#ffbfbfbf" />
+      </Grid>
+    </Popup>
+  </StackPanel>
+</UserControl>

--- a/ItemBoxTracker/GUI/AutoSuggestBox.xaml
+++ b/ItemBoxTracker/GUI/AutoSuggestBox.xaml
@@ -5,15 +5,27 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:convert="clr-namespace:MHWItemBoxTracker.Converters"
+    xmlns:hp-convert="clr-namespace:HunterPie.UI.Infrastructure.Converters;assembly=HunterPie.UI"
     mc:Ignorable="d"
     Margin="10,0,10,5"
+    Loaded="OnLoaded"
     d:DesignWidth="200">
   <UserControl.Resources>
     <ResourceDictionary>
       <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="ButtonOverride.xaml" />
         <ResourceDictionary>
-          <BooleanToVisibilityConverter x:Key="bool2Visibility" />
+          <hp-convert:LengthToVisibilityConverter
+              WhenEmpty="Hidden"
+              WhenValues="Visible"
+              x:Key="emptyVisible" />
+        </ResourceDictionary>
+        <ResourceDictionary>
+          <hp-convert:BooleanToVisibilityConverter
+              x:Key="InverseBool2Visibility"
+              FalseValue="Visible"
+              TrueValue="Hidden" />
         </ResourceDictionary>
       </ResourceDictionary.MergedDictionaries>
     </ResourceDictionary>
@@ -37,7 +49,7 @@
             Grid.Column='0'
             Text="{Binding Placeholder}"
             Foreground="#cc9E9D9D"
-            Visibility="{Binding Text.IsEmpty, ElementName=searchInput, Converter={StaticResource bool2Visibility}}" />
+            Visibility="{Binding Text.IsEmpty, ElementName=searchInput, Converter={hp-convert:BooleanToVisibilityConverter}}" />
         <TextBox
             Grid.Column='0'
             x:Name="searchInput"
@@ -62,8 +74,7 @@
             Grid.Column='0'
             CornerRadius="5"
             Background="#1e5878"
-            Visibility="Collapsed"
-            x:Name="selectionCtrl">
+            Visibility="{Binding IsEnabled, ElementName=searchInput, Converter={StaticResource InverseBool2Visibility}}">
           <Grid>
             <Grid.ColumnDefinitions>
               <ColumnDefinition Width="*" />
@@ -85,14 +96,14 @@
         <TextBlock
             Grid.Column='1'
             Text="🔎"
-            Visibility="{Binding IsEnabled, ElementName=searchInput, Converter={StaticResource bool2Visibility}}"
+            Visibility="{Binding IsEnabled, ElementName=searchInput, Converter={hp-convert:BooleanToVisibilityConverter}}"
             Foreground="#cc9E9D9D" />
       </Grid>
     </Border>
 
     <Popup
         x:Name="suggestionsPopup"
-        Visibility="{Binding IsOpen, ElementName=suggestionsPopup, Converter={StaticResource bool2Visibility}}"
+        Visibility="{Binding IsOpen, ElementName=suggestionsPopup, Converter={hp-convert:BooleanToVisibilityConverter}}"
         MinWidth="{Binding ActualWidth}"
         MinHeight="30"
         MaxHeight="150"
@@ -101,11 +112,12 @@
       <Grid>
         <ListBox
             x:Name="suggestionsList"
+            Visibility="{Binding Suggestions.Count, Converter={hp-convert:LengthToVisibilityConverter}}"
             SelectionChanged="SelectionChanged"
             ItemTemplate="{Binding ItemTemplate}" />
 
         <TextBlock
-            x:Name="noResults"
+            Visibility="{Binding Suggestions.Count, Converter={StaticResource emptyVisible}}"
             Text="No results..."
             VerticalAlignment="Center"
             Padding="5 0"

--- a/ItemBoxTracker/GUI/AutoSuggestBox.xaml
+++ b/ItemBoxTracker/GUI/AutoSuggestBox.xaml
@@ -95,7 +95,6 @@
       <Grid>
         <ListBox
             x:Name="suggestionsList"
-            Visibility="{Binding HasItems, ElementName=suggestionsList, Converter={StaticResource bool2Visibility}}"
             SelectionChanged="SelectionChanged"
             ItemTemplate="{Binding ItemTemplate}" />
 

--- a/ItemBoxTracker/GUI/AutoSuggestBox.xaml
+++ b/ItemBoxTracker/GUI/AutoSuggestBox.xaml
@@ -5,8 +5,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:convert="clr-namespace:MHWItemBoxTracker.Converters"
-    xmlns:hp-convert="clr-namespace:HunterPie.UI.Infrastructure.Converters;assembly=HunterPie.UI"
+    xmlns:convert="clr-namespace:HunterPie.UI.Infrastructure.Converters;assembly=HunterPie.UI"
     mc:Ignorable="d"
     Margin="10,0,10,5"
     Loaded="OnLoaded"
@@ -16,7 +15,7 @@
       <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="ButtonOverride.xaml" />
         <ResourceDictionary>
-          <hp-convert:BooleanToVisibilityConverter
+          <convert:BooleanToVisibilityConverter
               x:Key="InverseBool2Visibility"
               FalseValue="Visible"
               TrueValue="Hidden" />
@@ -43,7 +42,7 @@
             Grid.Column='0'
             Text="{Binding Placeholder}"
             Foreground="#cc9E9D9D"
-            Visibility="{Binding Text.IsEmpty, ElementName=searchInput, Converter={hp-convert:BooleanToVisibilityConverter}}" />
+            Visibility="{Binding Text.IsEmpty, ElementName=searchInput, Converter={convert:BooleanToVisibilityConverter}}" />
         <TextBox
             Grid.Column='0'
             x:Name="searchInput"
@@ -93,14 +92,14 @@
         <TextBlock
             Grid.Column='1'
             Text="🔎"
-            Visibility="{Binding IsEnabled, ElementName=searchInput, Converter={hp-convert:BooleanToVisibilityConverter}}"
+            Visibility="{Binding IsEnabled, ElementName=searchInput, Converter={convert:BooleanToVisibilityConverter}}"
             Foreground="#cc9E9D9D" />
       </Grid>
     </Border>
 
     <Popup
         x:Name="suggestionsPopup"
-        Visibility="{Binding IsOpen, ElementName=suggestionsPopup, Converter={hp-convert:BooleanToVisibilityConverter}}"
+        Visibility="{Binding IsOpen, ElementName=suggestionsPopup, Converter={convert:BooleanToVisibilityConverter}}"
         MinWidth="{Binding ActualWidth}"
         MinHeight="30"
         MaxHeight="150"

--- a/ItemBoxTracker/GUI/AutoSuggestBox.xaml
+++ b/ItemBoxTracker/GUI/AutoSuggestBox.xaml
@@ -16,12 +16,6 @@
       <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="ButtonOverride.xaml" />
         <ResourceDictionary>
-          <hp-convert:LengthToVisibilityConverter
-              WhenEmpty="Hidden"
-              WhenValues="Visible"
-              x:Key="emptyVisible" />
-        </ResourceDictionary>
-        <ResourceDictionary>
           <hp-convert:BooleanToVisibilityConverter
               x:Key="InverseBool2Visibility"
               FalseValue="Visible"
@@ -112,12 +106,13 @@
       <Grid>
         <ListBox
             x:Name="suggestionsList"
-            Visibility="{Binding Suggestions.Count, Converter={hp-convert:LengthToVisibilityConverter}}"
+            Background="{x:Null}"
             SelectionChanged="SelectionChanged"
             ItemTemplate="{Binding ItemTemplate}" />
 
         <TextBlock
-            Visibility="{Binding Suggestions.Count, Converter={StaticResource emptyVisible}}"
+            x:Name="noResults"
+            Background="{x:Null}"
             Text="No results..."
             VerticalAlignment="Center"
             Padding="5 0"

--- a/ItemBoxTracker/GUI/AutoSuggestBox.xaml
+++ b/ItemBoxTracker/GUI/AutoSuggestBox.xaml
@@ -49,6 +49,12 @@
                 Key="Return"
                 Command="{Binding OnEnter}"
                 CommandParameter="{Binding ElementName=searchInput, Path=Text}" />
+            <KeyBinding
+                Key="Down"
+                Command="{Binding OnDownKey}" />
+            <KeyBinding
+                Key="Up"
+                Command="{Binding OnUpKey}" />
           </TextBox.InputBindings>
         </TextBox>
 

--- a/ItemBoxTracker/GUI/AutoSuggestBox.xaml
+++ b/ItemBoxTracker/GUI/AutoSuggestBox.xaml
@@ -61,6 +61,9 @@
             <KeyBinding
                 Key="Up"
                 Command="{Binding OnUpKey}" />
+            <KeyBinding
+                Key="Escape"
+                Command="{Binding OnEscape}" />
           </TextBox.InputBindings>
         </TextBox>
 

--- a/ItemBoxTracker/GUI/AutoSuggestBox.xaml
+++ b/ItemBoxTracker/GUI/AutoSuggestBox.xaml
@@ -46,7 +46,7 @@
             TextChanged="TextChanged">
           <TextBox.InputBindings>
             <KeyBinding
-                Key="Return"
+                Key="Enter"
                 Command="{Binding OnEnter}"
                 CommandParameter="{Binding ElementName=searchInput, Path=Text}" />
             <KeyBinding

--- a/ItemBoxTracker/GUI/AutoSuggestBox.xaml
+++ b/ItemBoxTracker/GUI/AutoSuggestBox.xaml
@@ -9,7 +9,14 @@
     Margin="10,0,10,5"
     d:DesignWidth="200">
   <UserControl.Resources>
-    <BooleanToVisibilityConverter x:Key="bool2Visibility" />
+    <ResourceDictionary>
+      <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="ButtonOverride.xaml" />
+        <ResourceDictionary>
+          <BooleanToVisibilityConverter x:Key="bool2Visibility" />
+        </ResourceDictionary>
+      </ResourceDictionary.MergedDictionaries>
+    </ResourceDictionary>
   </UserControl.Resources>
 
   <StackPanel DataContext="{Binding ElementName=AutoSuggest}">
@@ -60,10 +67,12 @@
                 Grid.Column='0'
                 Content="{Binding Selection}"
                 ContentTemplate="{Binding ItemTemplate}" />
-            <TextBlock
+            <Button
                 Grid.Column='1'
-                Text="✘"
-                Foreground="#cc9E9D9D" />
+                Style="{StaticResource ButtonOverride}"
+                Foreground="#cc9E9D9D"
+                Click="ClearSelection"
+                Content="✘" />
           </Grid>
         </Border>
 

--- a/ItemBoxTracker/GUI/AutoSuggestBox.xaml.cs
+++ b/ItemBoxTracker/GUI/AutoSuggestBox.xaml.cs
@@ -28,6 +28,7 @@ namespace MHWItemBoxTracker.GUI {
       selectionCtrl.Visibility = Visibility.Collapsed;
       OnClearSelection(Selection);
       searchInput.IsEnabled = true;
+      searchInput.Focus();
     }
     public void OnEnter(string input) {
       if (!string.IsNullOrEmpty(input)) {

--- a/ItemBoxTracker/GUI/AutoSuggestBox.xaml.cs
+++ b/ItemBoxTracker/GUI/AutoSuggestBox.xaml.cs
@@ -1,15 +1,10 @@
 using System;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
-using System.ComponentModel;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Data;
 using System.Windows.Input;
-using HunterPie.Plugins;
-using HunterPie.UI;
 using HunterPie.UI.Infrastructure;
-using static MHWItemBoxTracker.Main;
 
 namespace MHWItemBoxTracker.GUI {
   public partial class AutoSuggestBox : UserControl {

--- a/ItemBoxTracker/GUI/AutoSuggestBox.xaml.cs
+++ b/ItemBoxTracker/GUI/AutoSuggestBox.xaml.cs
@@ -101,6 +101,7 @@ namespace MHWItemBoxTracker.GUI {
       OnEnter = new RelayCommand(i => onEnter(i as string));
       OnDownKey = new ArglessRelayCommand(onDownKey);
       OnUpKey = new ArglessRelayCommand(onUpKey);
+      OnEscape = new ArglessRelayCommand(onEscape);
       InitializeComponent();
       suggestionsList.ItemsSource = Suggestions;
       Suggestions.CollectionChanged += SuggestionsChanged;
@@ -132,6 +133,7 @@ namespace MHWItemBoxTracker.GUI {
     public ICommand OnEnter { get; }
     public ICommand OnDownKey { get; }
     public ICommand OnUpKey { get; }
+    public ICommand OnEscape { get; }
     private void onEnter(string input) {
       if (suggestionsList.SelectedIndex >= 0) {
         DisplaySelection();
@@ -155,6 +157,9 @@ namespace MHWItemBoxTracker.GUI {
         itIsI = true;
         suggestionsList.SelectedIndex--;
       }
+    }
+    private void onEscape() {
+      suggestionsPopup.IsOpen = false;
     }
 
     private void OnLoaded(object sender, RoutedEventArgs e) {

--- a/ItemBoxTracker/GUI/AutoSuggestBox.xaml.cs
+++ b/ItemBoxTracker/GUI/AutoSuggestBox.xaml.cs
@@ -1,11 +1,14 @@
 using System;
+using System.Collections.ObjectModel;
 using System.Windows;
 using System.Windows.Controls;
 
 namespace MHWItemBoxTracker.GUI {
   public partial class AutoSuggestBox : UserControl {
+    public ObservableCollection<object> Suggestions { get; } = new ObservableCollection<object>();
     public AutoSuggestBox() {
       InitializeComponent();
+      suggestionsList.ItemsSource = Suggestions;
     }
 
     private void TextChanged(object sender, TextChangedEventArgs e) {
@@ -13,9 +16,10 @@ namespace MHWItemBoxTracker.GUI {
         suggestionsPopup.IsOpen = false;
       } else {
         suggestionsPopup.IsOpen = true;
-        OnTextChanged(suggestionsList, searchInput.Text);
+        OnTextChanged(Suggestions, searchInput.Text);
       }
-      noResults.Visibility = Bool2Visibility(!suggestionsList.HasItems);
+      noResults.Visibility = Bool2Visibility(Suggestions.Count == 0);
+      suggestionsList.Visibility = Bool2Visibility(Suggestions.Count > 0);
     }
 
     private void SelectionChanged(object sender, SelectionChangedEventArgs e) {
@@ -32,19 +36,20 @@ namespace MHWItemBoxTracker.GUI {
     }
     public void OnEnter(string input) {
       if (!string.IsNullOrEmpty(input)) {
-        OnTextChanged(suggestionsList, input);
-        if (suggestionsList.HasItems) {
+        OnTextChanged(Suggestions, input);
+        if (Suggestions.Count > 0) {
           suggestionsPopup.IsOpen = false;
           suggestionsList.SelectedIndex = 0;
           DisplaySelection();
         }
-        noResults.Visibility = Bool2Visibility(!suggestionsList.HasItems);
+        noResults.Visibility = Bool2Visibility(Suggestions.Count == 0);
+        suggestionsList.Visibility = Bool2Visibility(Suggestions.Count > 0);
       }
     }
 
     private void DisplaySelection() {
       selectionCtrl.Visibility = Visibility.Visible;
-      OnSuggestionChosen(Selection, suggestionsList.SelectedItem as ListBoxItem);
+      OnSuggestionChosen(Selection, suggestionsList.SelectedItem);
       suggestionsList.SelectedIndex = -1;
 
       searchInput.Clear();
@@ -55,9 +60,10 @@ namespace MHWItemBoxTracker.GUI {
       return isVisible ? Visibility.Visible : Visibility.Collapsed;
     }
 
-    public event Action<ListBox, string> OnTextChanged = (l, s) => { };
+    public event Action<ObservableCollection<object>, string> OnTextChanged = (l, s) => { };
     public event Action<object> OnClearSelection = o => { };
-    public event Action<object, ListBoxItem> OnSuggestionChosen = (o, l) => { };
+    // TODO Both are same type
+    public event Action<object, object> OnSuggestionChosen = (o, l) => { };
 
     public static readonly DependencyProperty PlaceholderProperty = DependencyProperty.Register(
     "Placeholder", typeof(string), typeof(AutoSuggestBox), new PropertyMetadata("Search..."));

--- a/ItemBoxTracker/GUI/AutoSuggestBox.xaml.cs
+++ b/ItemBoxTracker/GUI/AutoSuggestBox.xaml.cs
@@ -1,12 +1,16 @@
 using System;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
+using System.ComponentModel;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Data;
 using System.Windows.Input;
+using HunterPie.Plugins;
+using HunterPie.UI;
 using HunterPie.UI.Infrastructure;
 using MHWItemBoxTracker.Converters;
+using static MHWItemBoxTracker.Main;
 
 namespace MHWItemBoxTracker.GUI {
   public partial class AutoSuggestBox : UserControl {
@@ -99,6 +103,7 @@ namespace MHWItemBoxTracker.GUI {
       OnUpKey = new ArglessRelayCommand(onUpKey);
       InitializeComponent();
       suggestionsList.ItemsSource = Suggestions;
+      Suggestions.CollectionChanged += SuggestionsChanged;
     }
     private ObservableCollection<object> Suggestions { get; } = new ObservableCollection<object>();
     private bool itIsI = false;
@@ -159,6 +164,11 @@ namespace MHWItemBoxTracker.GUI {
       }
     }
 
+    void SuggestionsChanged(object sender, NotifyCollectionChangedEventArgs e) {
+      var isEmpty = Suggestions.Count == 0;
+      suggestionsList.Visibility = isEmpty ? Visibility.Collapsed : Visibility.Visible;
+      noResults.Visibility = isEmpty ? Visibility.Visible : Visibility.Collapsed;
+    }
     private void DisplaySelection() {
       suggestionsPopup.IsOpen = false;
       OnSuggestionChosen(Selection, suggestionsList.SelectedItem);

--- a/ItemBoxTracker/GUI/AutoSuggestBox.xaml.cs
+++ b/ItemBoxTracker/GUI/AutoSuggestBox.xaml.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Windows;
+using System.Windows.Controls;
+
+namespace MHWItemBoxTracker.GUI {
+  public partial class AutoSuggestBox : UserControl {
+    public AutoSuggestBox() {
+      InitializeComponent();
+    }
+
+    private void TextChanged(object sender, TextChangedEventArgs e) {
+      if (string.IsNullOrEmpty(searchInput.Text)) {
+        suggestionsPopup.IsOpen = false;
+      } else {
+        suggestionsPopup.IsOpen = true;
+        OnTextChanged(suggestionsList, searchInput.Text);
+      }
+      noResults.Visibility = Bool2Visibility(!suggestionsList.HasItems);
+    }
+
+    private void SelectionChanged(object sender, SelectionChangedEventArgs e) {
+      suggestionsPopup.IsOpen = false;
+      if (suggestionsList.SelectedIndex >= 0) {
+        DisplaySelection();
+      }
+    }
+    private void ClearSelection(object sender, RoutedEventArgs e) {
+      selectionCtrl.Visibility = Visibility.Collapsed;
+      OnClearSelection(Selection);
+      searchInput.IsEnabled = true;
+    }
+    public void OnEnter(string input) {
+      if (!string.IsNullOrEmpty(input)) {
+        OnTextChanged(suggestionsList, input);
+        if (suggestionsList.HasItems) {
+          suggestionsPopup.IsOpen = false;
+          suggestionsList.SelectedIndex = 0;
+          DisplaySelection();
+        }
+        noResults.Visibility = Bool2Visibility(!suggestionsList.HasItems);
+      }
+    }
+
+    private void DisplaySelection() {
+      selectionCtrl.Visibility = Visibility.Visible;
+      OnSuggestionChosen(Selection, suggestionsList.SelectedItem as ListBoxItem);
+      suggestionsList.SelectedIndex = -1;
+
+      searchInput.Clear();
+      searchInput.IsEnabled = false;
+    }
+
+    private Visibility Bool2Visibility(bool isVisible) {
+      return isVisible ? Visibility.Visible : Visibility.Collapsed;
+    }
+
+    public event Action<ListBox, string> OnTextChanged = (l, s) => { };
+    public event Action<object> OnClearSelection = o => { };
+    public event Action<object, ListBoxItem> OnSuggestionChosen = (o, l) => { };
+
+    public static readonly DependencyProperty PlaceholderProperty = DependencyProperty.Register(
+    "Placeholder", typeof(string), typeof(AutoSuggestBox), new PropertyMetadata("Search..."));
+
+    public string Placeholder {
+      get { return (string)GetValue(PlaceholderProperty); }
+      set { SetValue(PlaceholderProperty, value); }
+    }
+    public static readonly DependencyProperty SelectionProperty = DependencyProperty.Register(
+    "Selection", typeof(object), typeof(AutoSuggestBox), new PropertyMetadata(null));
+
+    public object Selection {
+      get { return (object)GetValue(SelectionProperty); }
+      set { SetValue(SelectionProperty, value); }
+    }
+    public static readonly DependencyProperty ItemTemplateProperty = DependencyProperty.Register(
+    "ItemTemplate", typeof(DataTemplate), typeof(AutoSuggestBox), new PropertyMetadata(default(DataTemplate)));
+
+    public string ItemTemplate {
+      get { return (string)GetValue(ItemTemplateProperty); }
+      set { SetValue(ItemTemplateProperty, value); }
+    }
+  }
+}

--- a/ItemBoxTracker/GUI/AutoSuggestBox.xaml.cs
+++ b/ItemBoxTracker/GUI/AutoSuggestBox.xaml.cs
@@ -9,7 +9,6 @@ using System.Windows.Input;
 using HunterPie.Plugins;
 using HunterPie.UI;
 using HunterPie.UI.Infrastructure;
-using MHWItemBoxTracker.Converters;
 using static MHWItemBoxTracker.Main;
 
 namespace MHWItemBoxTracker.GUI {

--- a/ItemBoxTracker/GUI/AutoSuggestBox.xaml.cs
+++ b/ItemBoxTracker/GUI/AutoSuggestBox.xaml.cs
@@ -1,9 +1,12 @@
 using System;
 using System.Collections.ObjectModel;
+using System.Collections.Specialized;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Data;
 using System.Windows.Input;
 using HunterPie.UI.Infrastructure;
+using MHWItemBoxTracker.Converters;
 
 namespace MHWItemBoxTracker.GUI {
   public partial class AutoSuggestBox : UserControl {
@@ -107,8 +110,6 @@ namespace MHWItemBoxTracker.GUI {
         suggestionsPopup.IsOpen = true;
         OnTextChanged(Suggestions, searchInput.Text);
       }
-      noResults.Visibility = Bool2Visibility(Suggestions.Count == 0);
-      suggestionsList.Visibility = Bool2Visibility(Suggestions.Count > 0);
     }
 
     private void SelectionChanged(object sender, SelectionChangedEventArgs e) {
@@ -118,7 +119,6 @@ namespace MHWItemBoxTracker.GUI {
       itIsI = false;
     }
     private void ClearSelection(object sender, RoutedEventArgs e) {
-      selectionCtrl.Visibility = Visibility.Collapsed;
       OnClearSelection(Selection);
       searchInput.IsEnabled = true;
       searchInput.Focus();
@@ -136,8 +136,6 @@ namespace MHWItemBoxTracker.GUI {
           // triggers OnSelectionChanged, so no need to call DisplaySelection()
           suggestionsList.SelectedIndex = 0;
         }
-        noResults.Visibility = Bool2Visibility(Suggestions.Count == 0);
-        suggestionsList.Visibility = Bool2Visibility(Suggestions.Count > 0);
       }
     }
     private void onDownKey() {
@@ -154,18 +152,20 @@ namespace MHWItemBoxTracker.GUI {
       }
     }
 
+    private void OnLoaded(object sender, RoutedEventArgs e) {
+      var empty = Activator.CreateInstance(Selection.GetType());
+      if (!empty.Equals(Selection)) {
+        searchInput.IsEnabled = false;
+      }
+    }
+
     private void DisplaySelection() {
       suggestionsPopup.IsOpen = false;
-      selectionCtrl.Visibility = Visibility.Visible;
       OnSuggestionChosen(Selection, suggestionsList.SelectedItem);
       suggestionsList.SelectedIndex = -1;
 
-      searchInput.Clear();
       searchInput.IsEnabled = false;
-    }
-
-    private Visibility Bool2Visibility(bool isVisible) {
-      return isVisible ? Visibility.Visible : Visibility.Collapsed;
+      searchInput.Clear();
     }
   }
 }

--- a/ItemBoxTracker/GUI/ButtonOverride.xaml
+++ b/ItemBoxTracker/GUI/ButtonOverride.xaml
@@ -1,0 +1,42 @@
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+  <Style
+      TargetType="Button"
+      x:Key="ButtonOverride">
+    <Setter
+        Property="Cursor"
+        Value="Hand" />
+    <Setter
+        Property="Background"
+        Value="{x:Null}" />
+    <Setter
+        Property="BorderThickness"
+        Value="0" />
+    <Setter
+        Property="Padding"
+        Value="5 0" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="{x:Type Button}">
+          <Border
+              Background="{TemplateBinding Background}"
+              BorderThickness="{TemplateBinding BorderThickness}">
+            <ContentPresenter
+                HorizontalAlignment="Center"
+                VerticalAlignment="Center" />
+          </Border>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+    <Style.Triggers>
+      <Trigger
+          Property="IsMouseOver"
+          Value="True">
+        <Setter
+            Property="Opacity"
+            Value="0.8" />
+      </Trigger>
+    </Style.Triggers>
+  </Style>
+</ResourceDictionary>

--- a/ItemBoxTracker/GUI/ButtonOverride.xaml
+++ b/ItemBoxTracker/GUI/ButtonOverride.xaml
@@ -14,8 +14,11 @@
         Property="BorderThickness"
         Value="0" />
     <Setter
-        Property="Padding"
+        Property="Margin"
         Value="5 0" />
+    <Setter
+        Property="Foreground"
+        Value="#ffbfbfbf" />
     <Setter Property="Template">
       <Setter.Value>
         <ControlTemplate TargetType="{x:Type Button}">

--- a/ItemBoxTracker/GUI/DragAndDropper.xaml
+++ b/ItemBoxTracker/GUI/DragAndDropper.xaml
@@ -1,0 +1,10 @@
+<UserControl
+    x:Class="MHWItemBoxTracker.GUI.DragAndDropper"
+    x:Name="DragAndDrop"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    mc:Ignorable="d">
+  <ContentControl Content="{Binding Child, ElementName=DragAndDrop}" />
+</UserControl>

--- a/ItemBoxTracker/GUI/DragAndDropper.xaml.cs
+++ b/ItemBoxTracker/GUI/DragAndDropper.xaml.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Windows;
+using System.Windows.Controls;
+
+namespace MHWItemBoxTracker.GUI {
+  // TODO: revisit this some day
+  public partial class DragAndDropper : UserControl {
+
+    public ListView Child {
+      get { return (ListView)GetValue(ChildProperty); }
+      set { SetValue(ChildProperty, value); }
+    }
+    public static readonly DependencyProperty ChildProperty = DependencyProperty.Register(
+    "Child", typeof(ListView), typeof(DragAndDropper), new PropertyMetadata(null));
+    public DragAndDropper() : base() {
+      InitializeComponent();
+    }
+  }
+}

--- a/ItemBoxTracker/GUI/DragAndDropper.xaml.cs
+++ b/ItemBoxTracker/GUI/DragAndDropper.xaml.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Windows;
 using System.Windows.Controls;
 

--- a/ItemBoxTracker/GUI/ItemBoxTracker.xaml.cs
+++ b/ItemBoxTracker/GUI/ItemBoxTracker.xaml.cs
@@ -1,57 +1,46 @@
-﻿using HunterPie.GUI;
-using HunterPie.Core;
+﻿using System.Collections.Generic;
 using HunterPie.Core.Settings;
-using System.Collections.Generic;
-using System.Windows;
-using MHWItemBoxTracker.Config;
-using MHWItemBoxTracker.Utils;
-using System.Linq;
+using HunterPie.GUI;
 using HunterPie.Plugins;
+using MHWItemBoxTracker.Config;
 using static MHWItemBoxTracker.Main;
 using static MHWItemBoxTracker.Utils.Dispatcher;
 
-using Newtonsoft.Json;
-
-namespace MHWItemBoxTracker.GUI
-{
-    public partial class ItemBoxTracker : Widget
-    {
-        private static string settingsJson = "widget.settings.json";
-        private ItemBoxWidgetSettings widgetSettings {get; set;}
-        public override IWidgetSettings Settings => widgetSettings;
-        public ItemBoxTracker() : base()
-        {
-            InitializeComponent();
-            Dispatch(async () => {
-                widgetSettings = await Plugin.LoadJson<ItemBoxWidgetSettings>(settingsJson);
-                ApplySettings();
-            });
-        }
-
-        public void setItemsToDisplay(List<ItemBoxRow> itemBoxRows)
-        {
-            // Debugger.Log($"Theme: {UserSettings.PlayerConfig.HunterPie.Theme}");
-            theList.ItemsSource = itemBoxRows;
-            WidgetHasContent = (itemBoxRows.Count > 0);
-            ChangeVisibility();
-        }
-
-        public override void EnterWidgetDesignMode() {
-            base.EnterWidgetDesignMode();
-            RemoveWindowTransparencyFlag();
-        }
-
-        public override void LeaveWidgetDesignMode() {
-            base.LeaveWidgetDesignMode();
-            ApplyWindowTransparencyFlag();
-            Dispatch(async () => { await Plugin.SaveJson(settingsJson, widgetSettings); });
-        }
+namespace MHWItemBoxTracker.GUI {
+  public partial class ItemBoxTracker : Widget {
+    private static readonly string settingsJson = "widget.settings.json";
+    private ItemBoxWidgetSettings widgetSettings { get; set; }
+    public override IWidgetSettings Settings => widgetSettings;
+    public ItemBoxTracker() : base() {
+      InitializeComponent();
+      Dispatch(async () => {
+        widgetSettings = await Plugin.LoadJson<ItemBoxWidgetSettings>(settingsJson);
+        ApplySettings();
+      });
     }
 
-    public class ItemBoxRow
-    {
-        public string name { get; set; }
-        public string ratio { get; set; }
-        public double progress { get; set; }
+    public void setItemsToDisplay(List<ItemBoxRow> itemBoxRows) {
+      // Debugger.Log($"Theme: {UserSettings.PlayerConfig.HunterPie.Theme}");
+      theList.ItemsSource = itemBoxRows;
+      WidgetHasContent = (itemBoxRows.Count > 0);
+      ChangeVisibility();
     }
+
+    public override void EnterWidgetDesignMode() {
+      base.EnterWidgetDesignMode();
+      RemoveWindowTransparencyFlag();
+    }
+
+    public override void LeaveWidgetDesignMode() {
+      base.LeaveWidgetDesignMode();
+      ApplyWindowTransparencyFlag();
+      Dispatch(async () => { await Plugin.SaveJson(settingsJson, widgetSettings); });
+    }
+  }
+
+  public class ItemBoxRow {
+    public string name { get; set; }
+    public string ratio { get; set; }
+    public double progress { get; set; }
+  }
 }

--- a/ItemBoxTracker/GUI/ItemDataTemplate.xaml
+++ b/ItemBoxTracker/GUI/ItemDataTemplate.xaml
@@ -1,18 +1,20 @@
 <ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:convert="clr-namespace:MHWItemBoxTracker.Converter">
   <DataTemplate x:Key="ItemDataTemplate">
     <StackPanel Orientation="Horizontal">
       <StackPanel.ToolTip>
-        <StackPanel Orientation="Horizontal">
+        <StackPanel>
           <TextBlock
               Foreground="#ffbfbfbf"
               Padding="5 0"
-              Text="ItemId:" />
+              Text="{Binding ItemId, StringFormat=ItemId: 0x{0:x4}}" />
           <TextBlock
               Foreground="#ffbfbfbf"
-              Padding="5 0"
-              Text="{Binding ItemId}" />
+              Padding="5 5"
+              TextWrapping="Wrap"
+              Text="{Binding ItemId, Converter={convert:ItemIdToDescription}}" />
           <!-- <TextBlock Foreground="#ffbfbfbf" Text="{Binding ItemId, Converter={StaticResource dec2hex}}" /> -->
         </StackPanel>
       </StackPanel.ToolTip>

--- a/ItemBoxTracker/GUI/ItemDataTemplate.xaml
+++ b/ItemBoxTracker/GUI/ItemDataTemplate.xaml
@@ -23,6 +23,7 @@
           MaxWidth="30"
           Padding="5 0" /> -->
       <TextBlock
+          Padding="5 0"
           Text="{Binding Name}"
           Foreground="#ffbfbfbf" />
     </StackPanel>

--- a/ItemBoxTracker/GUI/ItemDataTemplate.xaml
+++ b/ItemBoxTracker/GUI/ItemDataTemplate.xaml
@@ -17,11 +17,6 @@
         </StackPanel>
       </StackPanel.ToolTip>
 
-      <TextBlock
-          Text="🚧"
-          Padding="5 0"
-          Foreground="Yellow" />
-
       <!-- <Image
           Source="{Binding ItemId, Converter={StaticResource id2icon}}"
           MaxHeight="30"

--- a/ItemBoxTracker/GUI/ItemDataTemplate.xaml
+++ b/ItemBoxTracker/GUI/ItemDataTemplate.xaml
@@ -1,0 +1,35 @@
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+  <DataTemplate x:Key="ItemDataTemplate">
+    <StackPanel Orientation="Horizontal">
+      <StackPanel.ToolTip>
+        <StackPanel Orientation="Horizontal">
+          <TextBlock
+              Foreground="#ffbfbfbf"
+              Padding="5 0"
+              Text="ItemId:" />
+          <TextBlock
+              Foreground="#ffbfbfbf"
+              Padding="5 0"
+              Text="{Binding ItemId}" />
+          <!-- <TextBlock Foreground="#ffbfbfbf" Text="{Binding ItemId, Converter={StaticResource dec2hex}}" /> -->
+        </StackPanel>
+      </StackPanel.ToolTip>
+
+      <TextBlock
+          Text="🚧"
+          Padding="5 0"
+          Foreground="Yellow" />
+
+      <!-- <Image
+          Source="{Binding ItemId, Converter={StaticResource id2icon}}"
+          MaxHeight="30"
+          MaxWidth="30"
+          Padding="5 0" /> -->
+      <TextBlock
+          Text="{Binding Name}"
+          Foreground="#ffbfbfbf" />
+    </StackPanel>
+  </DataTemplate>
+</ResourceDictionary>

--- a/ItemBoxTracker/GUI/Settings.xaml
+++ b/ItemBoxTracker/GUI/Settings.xaml
@@ -1,4 +1,5 @@
 ﻿<UserControl x:Class="MHWItemBoxTracker.GUI.Settings"
+             xmlns:local="clr-namespace:MHWItemBoxTracker.GUI"
              xmlns:src="clr-namespace:HunterPie.GUI;assembly=HunterPie.UI"
              xmlns:Custom="clr-namespace:HunterPie.GUIControls.Custom_Controls;assembly=HunterPie.UI"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
@@ -11,36 +12,16 @@
     <TabControl.Background>
       <SolidColorBrush Color="#00000000" Opacity="0"/>
     </TabControl.Background>
+
     <TabItem Header="Always" Width="150" Margin="1 0">
-      <StackPanel>
-
-        <Custom:Switcher Text="Track items in pouch" />
-        <Custom:Switcher Text="Track items in box" />
-        <Custom:Switcher Text="Track craftable items" />
-
-        <GroupBox Header="Items to track"
-                  Foreground="WhiteSmoke"
-                  BorderBrush="{x:Null}">
-            <StackPanel>
-                <StackPanel Orientation="Horizontal">
-                    <Custom:MinimalButton Text="↕" />
-                    <Custom:ComboBox Label="Item" Width="200" SelectedItem="Red Orb" />
-                    <Custom:TextInput Label="Amount" Width="100" Text="19" />
-                    <Custom:MinimalButton Foreground="Red" Text="✘" />
-                </StackPanel>
-                <StackPanel Orientation="Horizontal">
-                    <Custom:MinimalButton Text="↕" />
-                    <Custom:ComboBox Label="Item" Width="200" SelectedItem="Potion" />
-                    <Custom:TextInput Label="Amount" Width="100" Text="999" />
-                    <Custom:MinimalButton Foreground="Red" Text="✘" />
-                </StackPanel>
-                <Button Content="Add another" Width="100" HorizontalAlignment="Right" Style="{StaticResource buttons_settings}" />
-            </StackPanel>
-        </GroupBox>
-
-      </StackPanel>
+      <local:SettingsTab />
     </TabItem>
-    <TabItem Header="Village"  Width="150"  Margin="1 0" />
-    <TabItem Header="Quest"  Width="150"  Margin="1 0" />
+    <TabItem Header="Village"  Width="150"  Margin="1 0">
+      <local:SettingsTab />
+    </TabItem>
+    <TabItem Header="Quest"  Width="150"  Margin="1 0">
+      <local:SettingsTab />
+    </TabItem>
+
   </TabControl>
 </UserControl>

--- a/ItemBoxTracker/GUI/Settings.xaml
+++ b/ItemBoxTracker/GUI/Settings.xaml
@@ -1,25 +1,38 @@
-﻿<UserControl x:Class="MHWItemBoxTracker.GUI.Settings"
-             xmlns:local="clr-namespace:MHWItemBoxTracker.GUI"
-             xmlns:src="clr-namespace:HunterPie.GUI;assembly=HunterPie.UI"
-             xmlns:Custom="clr-namespace:HunterPie.GUIControls.Custom_Controls;assembly=HunterPie.UI"
-             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             d:DesignHeight="450" d:DesignWidth="800"
-             mc:Ignorable="d">
+﻿<UserControl
+    x:Class="MHWItemBoxTracker.GUI.Settings"
+    xmlns:local="clr-namespace:MHWItemBoxTracker.GUI"
+    xmlns:src="clr-namespace:HunterPie.GUI;assembly=HunterPie.UI"
+    xmlns:Custom="clr-namespace:HunterPie.GUIControls.Custom_Controls;assembly=HunterPie.UI"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    d:DesignHeight="450"
+    d:DesignWidth="800"
+    mc:Ignorable="d">
   <TabControl BorderThickness="0">
     <TabControl.Background>
-      <SolidColorBrush Color="#00000000" Opacity="0"/>
+      <SolidColorBrush
+          Color="#00000000"
+          Opacity="0" />
     </TabControl.Background>
 
-    <TabItem Header="Always" Width="150" Margin="1 0">
+    <TabItem
+        Header="Always"
+        Width="150"
+        Margin="1 0">
       <local:SettingsTab DataContext="{Binding Always}" />
     </TabItem>
-    <TabItem Header="Village"  Width="150"  Margin="1 0">
+    <TabItem
+        Header="Village"
+        Width="150"
+        Margin="1 0">
       <local:SettingsTab DataContext="{Binding Village}" />
     </TabItem>
-    <TabItem Header="Quest"  Width="150"  Margin="1 0">
+    <TabItem
+        Header="Quest"
+        Width="150"
+        Margin="1 0">
       <local:SettingsTab DataContext="{Binding Quest}" />
     </TabItem>
 

--- a/ItemBoxTracker/GUI/Settings.xaml
+++ b/ItemBoxTracker/GUI/Settings.xaml
@@ -7,8 +7,40 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              d:DesignHeight="450" d:DesignWidth="800"
              mc:Ignorable="d">
-    <StackPanel>
-    <Label Content="🚧" FontSize="128" HorizontalAlignment="Center" VerticalAlignment="Center" Background="Yellow" />
-    <Label Content="WIP... Come back later" FontSize="32" HorizontalAlignment="Center" VerticalAlignment="Center" />
-    </StackPanel>
+  <TabControl BorderThickness="0">
+    <TabControl.Background>
+      <SolidColorBrush Color="#00000000" Opacity="0"/>
+    </TabControl.Background>
+    <TabItem Header="Always" Width="150" Margin="1 0">
+      <StackPanel>
+
+        <Custom:Switcher Text="Track items in pouch" />
+        <Custom:Switcher Text="Track items in box" />
+        <Custom:Switcher Text="Track craftable items" />
+
+        <GroupBox Header="Items to track"
+                  Foreground="WhiteSmoke"
+                  BorderBrush="{x:Null}">
+            <StackPanel>
+                <StackPanel Orientation="Horizontal">
+                    <Custom:MinimalButton Text="↕" />
+                    <Custom:ComboBox Label="Item" Width="200" SelectedItem="Red Orb" />
+                    <Custom:TextInput Label="Amount" Width="100" Text="19" />
+                    <Custom:MinimalButton Foreground="Red" Text="✘" />
+                </StackPanel>
+                <StackPanel Orientation="Horizontal">
+                    <Custom:MinimalButton Text="↕" />
+                    <Custom:ComboBox Label="Item" Width="200" SelectedItem="Potion" />
+                    <Custom:TextInput Label="Amount" Width="100" Text="999" />
+                    <Custom:MinimalButton Foreground="Red" Text="✘" />
+                </StackPanel>
+                <Button Content="Add another" Width="100" HorizontalAlignment="Right" Style="{StaticResource buttons_settings}" />
+            </StackPanel>
+        </GroupBox>
+
+      </StackPanel>
+    </TabItem>
+    <TabItem Header="Village"  Width="150"  Margin="1 0" />
+    <TabItem Header="Quest"  Width="150"  Margin="1 0" />
+  </TabControl>
 </UserControl>

--- a/ItemBoxTracker/GUI/Settings.xaml
+++ b/ItemBoxTracker/GUI/Settings.xaml
@@ -14,13 +14,13 @@
     </TabControl.Background>
 
     <TabItem Header="Always" Width="150" Margin="1 0">
-      <local:SettingsTab />
+      <local:SettingsTab DataContext="{Binding Always}" />
     </TabItem>
     <TabItem Header="Village"  Width="150"  Margin="1 0">
-      <local:SettingsTab />
+      <local:SettingsTab DataContext="{Binding Village}" />
     </TabItem>
     <TabItem Header="Quest"  Width="150"  Margin="1 0">
-      <local:SettingsTab />
+      <local:SettingsTab DataContext="{Binding Quest}" />
     </TabItem>
 
   </TabControl>

--- a/ItemBoxTracker/GUI/Settings.xaml
+++ b/ItemBoxTracker/GUI/Settings.xaml
@@ -9,6 +9,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     d:DesignHeight="450"
     d:DesignWidth="800"
+    Loaded="OnLoaded"
     mc:Ignorable="d">
   <TabControl BorderThickness="0">
     <TabControl.Background>

--- a/ItemBoxTracker/GUI/Settings.xaml.cs
+++ b/ItemBoxTracker/GUI/Settings.xaml.cs
@@ -9,6 +9,7 @@ using HunterPie.Plugins;
 using HunterPie.UI.Infrastructure;
 using HunterPie.Settings;
 using MHWItemBoxTracker.Config;
+using MHWItemBoxTracker.ViewModels;
 using static MHWItemBoxTracker.Main;
 
 namespace MHWItemBoxTracker.GUI
@@ -18,12 +19,13 @@ namespace MHWItemBoxTracker.GUI
     public static string fileName = "settings.json";
     public bool IsSettingsChanged => true;
         
-    private ItemBoxTrackerConfig Config = new ItemBoxTrackerConfig();
+    private ItemBoxTrackerViewModel vm;
 
     public Settings()
     {
       InitializeComponent();
-      this.DataContext = Config;
+      vm = new ItemBoxTrackerViewModel(new ItemBoxTrackerConfig());
+      this.DataContext = vm;
     }
 
     public void LoadSettings() {

--- a/ItemBoxTracker/GUI/Settings.xaml.cs
+++ b/ItemBoxTracker/GUI/Settings.xaml.cs
@@ -8,33 +8,32 @@ using System.Windows.Media;
 using HunterPie.Plugins;
 using HunterPie.UI.Infrastructure;
 using HunterPie.Settings;
+using MHWItemBoxTracker.Config;
 using static MHWItemBoxTracker.Main;
 
 namespace MHWItemBoxTracker.GUI
 {
-    public partial class Settings : UserControl, ISettings {
+  public partial class Settings : UserControl, ISettings {
         
-        public static string fileName = "settings.json";
-        public bool IsSettingsChanged => true;
-        public string Title => ":D";
-        public int MaxLength => 45;
+    public static string fileName = "settings.json";
+    public bool IsSettingsChanged => true;
+        
+    private ItemBoxTrackerConfig Config = new ItemBoxTrackerConfig();
 
-        public Settings()
-        {
-            InitializeComponent();
-        }
-
-        public void LoadSettings() {
-            Plugin.Log("Load Settings, mudda fucca");
-        }
-
-        public void SaveSettings() {
-            Plugin.Log("Save Settings, mudda fucca");
-        }
-
-        public string ValidateSettings() {
-            Plugin.Log("Nothing here, mudda fucca");
-            return null;
-        }
+    public Settings()
+    {
+      InitializeComponent();
+      this.DataContext = Config;
     }
+
+    public void LoadSettings() {
+    }
+
+    public void SaveSettings() {
+    }
+
+    public string ValidateSettings() {
+      return null;
+    }
+  }
 }

--- a/ItemBoxTracker/GUI/Settings.xaml.cs
+++ b/ItemBoxTracker/GUI/Settings.xaml.cs
@@ -1,29 +1,20 @@
-using System;
-using System.Diagnostics;
-using System.IO;
-using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Input;
-using System.Windows.Media;
 using HunterPie.Plugins;
-using HunterPie.UI.Infrastructure;
 using HunterPie.Settings;
 using MHWItemBoxTracker.Config;
 using MHWItemBoxTracker.ViewModels;
-using static MHWItemBoxTracker.Main;
 using Newtonsoft.Json;
+using static MHWItemBoxTracker.Main;
 
-namespace MHWItemBoxTracker.GUI
-{
+namespace MHWItemBoxTracker.GUI {
   public partial class Settings : UserControl, ISettings {
-        
+
     public static string fileName = "settings.json";
     public bool IsSettingsChanged => true;
-        
-    private ItemBoxTrackerViewModel vm;
 
-    public Settings() : base()
-    {
+    private readonly ItemBoxTrackerViewModel vm;
+
+    public Settings() : base() {
       InitializeComponent();
       vm = new ItemBoxTrackerViewModel(new ItemBoxTrackerConfig());
       DataContext = vm;

--- a/ItemBoxTracker/GUI/Settings.xaml.cs
+++ b/ItemBoxTracker/GUI/Settings.xaml.cs
@@ -3,14 +3,10 @@ using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using HunterPie.Core.Native;
-using HunterPie.Plugins;
 using HunterPie.Settings;
 using MHWItemBoxTracker.Config;
 using MHWItemBoxTracker.Service;
 using MHWItemBoxTracker.ViewModels;
-using Newtonsoft.Json;
-using static MHWItemBoxTracker.Main;
-using static MHWItemBoxTracker.Utils.Dispatcher;
 
 namespace MHWItemBoxTracker.GUI {
   public partial class Settings : UserControl, ISettings {

--- a/ItemBoxTracker/GUI/Settings.xaml.cs
+++ b/ItemBoxTracker/GUI/Settings.xaml.cs
@@ -2,6 +2,7 @@ using System.Windows.Controls;
 using HunterPie.Plugins;
 using HunterPie.Settings;
 using MHWItemBoxTracker.Config;
+using MHWItemBoxTracker.Service;
 using MHWItemBoxTracker.ViewModels;
 using Newtonsoft.Json;
 using static MHWItemBoxTracker.Main;
@@ -11,23 +12,25 @@ namespace MHWItemBoxTracker.GUI {
   public partial class Settings : UserControl, ISettings {
     public bool IsSettingsChanged => true;
     private ItemBoxTrackerViewModel vm;
+    private ConfigService Config;
 
-    public Settings() : base() {
+    public Settings(ConfigService Config) : base() {
+      this.Config = Config;
       InitializeComponent();
       vm = new ItemBoxTrackerViewModel(new ItemBoxTrackerConfig());
       DataContext = vm;
     }
 
-    public void LoadSettings() {
-      Plugin.Log($"Loading Settings: {JsonConvert.SerializeObject(Plugin.Config, Formatting.Indented)}");
-      vm = new ItemBoxTrackerViewModel(Plugin.Config);
+    public async void LoadSettings() {
+      var config = await Config.LoadAsync();
+      Plugin.Log($"Loading Settings: {JsonConvert.SerializeObject(config, Formatting.Indented)}");
+      vm = new ItemBoxTrackerViewModel(config);
       DataContext = vm;
     }
 
-    public void SaveSettings() {
+    public async void SaveSettings() {
       Plugin.Log($"Saving Settings: {JsonConvert.SerializeObject(vm.ToConfig(), Formatting.Indented)}");
-      Plugin.Config = vm.ToConfig();
-      Dispatch(async () => await Plugin.SaveJson(settings, Plugin.Config));
+      await Config.SaveAsync(vm.ToConfig());
     }
 
     public string ValidateSettings() {

--- a/ItemBoxTracker/GUI/Settings.xaml.cs
+++ b/ItemBoxTracker/GUI/Settings.xaml.cs
@@ -1,4 +1,8 @@
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Windows;
 using System.Windows.Controls;
+using HunterPie.Core.Native;
 using HunterPie.Plugins;
 using HunterPie.Settings;
 using MHWItemBoxTracker.Config;
@@ -23,18 +27,36 @@ namespace MHWItemBoxTracker.GUI {
 
     public async void LoadSettings() {
       var config = await Config.LoadAsync();
-      Plugin.Log($"Loading Settings: {JsonConvert.SerializeObject(config, Formatting.Indented)}");
       vm = new ItemBoxTrackerViewModel(config);
       DataContext = vm;
     }
 
     public async void SaveSettings() {
-      Plugin.Log($"Saving Settings: {JsonConvert.SerializeObject(vm.ToConfig(), Formatting.Indented)}");
       await Config.SaveAsync(vm.ToConfig());
     }
 
     public string ValidateSettings() {
       return null;
+    }
+
+    private void OnLoaded(object sender, RoutedEventArgs e) {
+      LoadItems();
+    }
+
+    private void LoadItems() {
+      var items = new ObservableCollection<ItemViewModel>(Enumerable
+        .Range(0, GMD.Items.gValuesOffsets.Length / 2)
+        .Select(id => new ItemViewModel {
+          ItemId = id,
+          Name = GMD.GetItemNameById(id)
+        })
+        .Where(item => item.Name != null)
+        .ToList());
+
+      vm.Items.Clear();
+      foreach (var item in items) {
+        vm.Items.Add(item);
+      }
     }
   }
 }

--- a/ItemBoxTracker/GUI/Settings.xaml.cs
+++ b/ItemBoxTracker/GUI/Settings.xaml.cs
@@ -5,14 +5,12 @@ using MHWItemBoxTracker.Config;
 using MHWItemBoxTracker.ViewModels;
 using Newtonsoft.Json;
 using static MHWItemBoxTracker.Main;
+using static MHWItemBoxTracker.Utils.Dispatcher;
 
 namespace MHWItemBoxTracker.GUI {
   public partial class Settings : UserControl, ISettings {
-
-    public static string fileName = "settings.json";
     public bool IsSettingsChanged => true;
-
-    private readonly ItemBoxTrackerViewModel vm;
+    private ItemBoxTrackerViewModel vm;
 
     public Settings() : base() {
       InitializeComponent();
@@ -21,11 +19,15 @@ namespace MHWItemBoxTracker.GUI {
     }
 
     public void LoadSettings() {
-      Plugin.Log($"Loading Settings: {JsonConvert.SerializeObject(vm.ToConfig(), Formatting.Indented)}");
+      Plugin.Log($"Loading Settings: {JsonConvert.SerializeObject(Plugin.Config, Formatting.Indented)}");
+      vm = new ItemBoxTrackerViewModel(Plugin.Config);
+      DataContext = vm;
     }
 
     public void SaveSettings() {
       Plugin.Log($"Saving Settings: {JsonConvert.SerializeObject(vm.ToConfig(), Formatting.Indented)}");
+      Plugin.Config = vm.ToConfig();
+      Dispatch(async () => await Plugin.SaveJson(settings, Plugin.Config));
     }
 
     public string ValidateSettings() {

--- a/ItemBoxTracker/GUI/Settings.xaml.cs
+++ b/ItemBoxTracker/GUI/Settings.xaml.cs
@@ -11,6 +11,7 @@ using HunterPie.Settings;
 using MHWItemBoxTracker.Config;
 using MHWItemBoxTracker.ViewModels;
 using static MHWItemBoxTracker.Main;
+using Newtonsoft.Json;
 
 namespace MHWItemBoxTracker.GUI
 {
@@ -21,17 +22,19 @@ namespace MHWItemBoxTracker.GUI
         
     private ItemBoxTrackerViewModel vm;
 
-    public Settings()
+    public Settings() : base()
     {
       InitializeComponent();
       vm = new ItemBoxTrackerViewModel(new ItemBoxTrackerConfig());
-      this.DataContext = vm;
+      DataContext = vm;
     }
 
     public void LoadSettings() {
+      Plugin.Log($"Loading Settings: {JsonConvert.SerializeObject(vm.ToConfig(), Formatting.Indented)}");
     }
 
     public void SaveSettings() {
+      Plugin.Log($"Saving Settings: {JsonConvert.SerializeObject(vm.ToConfig(), Formatting.Indented)}");
     }
 
     public string ValidateSettings() {

--- a/ItemBoxTracker/GUI/SettingsTab.xaml
+++ b/ItemBoxTracker/GUI/SettingsTab.xaml
@@ -57,6 +57,9 @@
                     Placeholder="Search items..."
                     Selection="{Binding DataContext, ElementName=trackedItem, Mode=TwoWay}"
                     ItemTemplate="{StaticResource ItemDataTemplate}"
+                    OnTextChanged="OnTextChanged"
+                    OnSuggestionChosen="OnSuggestionChosen"
+                    OnClearSelection="OnClearSelection"
                     Width="250" />
                 <Custom:TextInput
                     Label="Amount"

--- a/ItemBoxTracker/GUI/SettingsTab.xaml
+++ b/ItemBoxTracker/GUI/SettingsTab.xaml
@@ -10,7 +10,6 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     d:DesignHeight="450"
     d:DesignWidth="800"
-    Loaded="OnLoaded"
     mc:Ignorable="d">
   <UserControl.Resources>
     <ResourceDictionary>

--- a/ItemBoxTracker/GUI/SettingsTab.xaml
+++ b/ItemBoxTracker/GUI/SettingsTab.xaml
@@ -12,7 +12,12 @@
     d:DesignWidth="800"
     mc:Ignorable="d">
   <UserControl.Resources>
-    <ResourceDictionary Source="ItemDataTemplate.xaml" />
+    <ResourceDictionary>
+      <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="ButtonOverride.xaml" />
+        <ResourceDictionary Source="ItemDataTemplate.xaml" />
+      </ResourceDictionary.MergedDictionaries>
+    </ResourceDictionary>
   </UserControl.Resources>
 
   <StackPanel>
@@ -57,9 +62,12 @@
                     Label="Amount"
                     Width="100"
                     Text="{Binding Amount, Mode=TwoWay}" />
-                <Custom:MinimalButton
+                <Button
+                    Grid.Column='1'
+                    Style="{StaticResource ButtonOverride}"
                     Foreground="Red"
-                    Text="✘" />
+                    Click="DeleteRow"
+                    Content="✘" />
               </StackPanel>
             </DataTemplate>
           </ListView.ItemTemplate>
@@ -68,6 +76,7 @@
             Content="Add another"
             Width="100"
             HorizontalAlignment="Right"
+            Click="AddRow"
             Style="{StaticResource buttons_settings}" />
       </StackPanel>
     </GroupBox>

--- a/ItemBoxTracker/GUI/SettingsTab.xaml
+++ b/ItemBoxTracker/GUI/SettingsTab.xaml
@@ -1,0 +1,36 @@
+<UserControl x:Class="MHWItemBoxTracker.GUI.SettingsTab"
+             xmlns:local="clr-namespace:MHWItemBoxTracker.Config"
+             xmlns:src="clr-namespace:HunterPie.GUI;assembly=HunterPie.UI"
+             xmlns:Custom="clr-namespace:HunterPie.GUIControls.Custom_Controls;assembly=HunterPie.UI"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             d:DesignHeight="450" d:DesignWidth="800"
+             mc:Ignorable="d">
+      <StackPanel>
+        <Custom:Switcher Text="Track items in pouch" />
+        <Custom:Switcher Text="Track items in box" />
+        <Custom:Switcher Text="Track craftable items" />
+
+        <GroupBox Header="Items to track"
+                  Foreground="WhiteSmoke"
+                  BorderBrush="{x:Null}">
+            <StackPanel>
+              <ListView x:Name="Items2Track">
+                <ListView.ItemTemplate>
+                  <DataTemplate>
+                    <StackPanel Orientation="Horizontal">
+                      <Custom:MinimalButton Text="↕" />
+                      <Custom:ComboBox Label="Item" Width="200" SelectedItem="Red Orb" />
+                      <Custom:TextInput Label="Amount" Width="100" Text="0" />
+                      <Custom:MinimalButton Foreground="Red" Text="✘" />
+                    </StackPanel>
+                  </DataTemplate>
+                </ListView.ItemTemplate>
+              </ListView>
+              <Button Content="Add another" Width="100" HorizontalAlignment="Right" Style="{StaticResource buttons_settings}" />
+            </StackPanel>
+        </GroupBox>
+      </StackPanel>
+</UserControl>

--- a/ItemBoxTracker/GUI/SettingsTab.xaml
+++ b/ItemBoxTracker/GUI/SettingsTab.xaml
@@ -21,6 +21,32 @@
   </UserControl.Resources>
 
   <StackPanel>
+
+
+    <Grid HorizontalAlignment="Center">
+      <Grid.ColumnDefinitions>
+        <ColumnDefinition Width="*" />
+        <ColumnDefinition Width="Auto" />
+        <ColumnDefinition Width="*" />
+      </Grid.ColumnDefinitions>
+      <TextBlock
+          Grid.Column="0"
+          Text="🚧"
+          Padding="5 0"
+          Foreground="Yellow"
+          FontSize="32" />
+      <TextBlock
+          Grid.Column="1"
+          Text="This is a WIP. Some settings don't do anything yet. They will soon, though..."
+          Foreground="#cc9E9D9D" />
+      <TextBlock
+          Grid.Column="2"
+          Text="🚧"
+          Padding="5 0"
+          Foreground="Yellow"
+          FontSize="32" />
+    </Grid>
+
     <Custom:Switcher
         Text="Track items in pouch"
         IsEnabled="{Binding TrackPouch, Mode=TwoWay}" />

--- a/ItemBoxTracker/GUI/SettingsTab.xaml
+++ b/ItemBoxTracker/GUI/SettingsTab.xaml
@@ -36,6 +36,12 @@
         Foreground="WhiteSmoke"
         BorderBrush="{x:Null}">
       <StackPanel>
+        <Button
+            Content="Add another"
+            Width="100"
+            HorizontalAlignment="Right"
+            Click="AddRow"
+            Style="{StaticResource buttons_settings}" />
         <local:DragAndDropper>
           <local:DragAndDropper.Child>
             <ListView
@@ -50,9 +56,16 @@
                 <!-- <DataTemplate x:DataType="vm:ItemViewModel"> -->
                 <DataTemplate>
                   <StackPanel Orientation="Horizontal">
-                    <Custom:MinimalButton
-                        Text="↕"
-                        Foreground="#ffbfbfbf" />
+                    <Button
+                        Style="{StaticResource ButtonOverride}"
+                        ToolTip="Move up"
+                        Click="MoveUp"
+                        Content="▲" />
+                    <Button
+                        Style="{StaticResource ButtonOverride}"
+                        ToolTip="Move down"
+                        Click="MoveDown"
+                        Content="▼" />
                     <local:AutoSuggestBox
                         Placeholder="Search items..."
                         Selection="{Binding DataContext, RelativeSource={RelativeSource AncestorType=StackPanel}, Mode=TwoWay}"
@@ -63,11 +76,12 @@
                         Width="250" />
                     <Custom:TextInput
                         Label="Amount"
+                        IsEnabled="{Binding ItemId}"
                         Width="100"
                         Text="{Binding Amount, Mode=TwoWay}" />
                     <Button
-                        Grid.Column='1'
                         Style="{StaticResource ButtonOverride}"
+                        ToolTip="Delete row"
                         Foreground="Red"
                         Click="DeleteRow"
                         Content="✘" />
@@ -77,12 +91,6 @@
             </ListView>
           </local:DragAndDropper.Child>
         </local:DragAndDropper>
-        <Button
-            Content="Add another"
-            Width="100"
-            HorizontalAlignment="Right"
-            Click="AddRow"
-            Style="{StaticResource buttons_settings}" />
       </StackPanel>
     </GroupBox>
   </StackPanel>

--- a/ItemBoxTracker/GUI/SettingsTab.xaml
+++ b/ItemBoxTracker/GUI/SettingsTab.xaml
@@ -1,5 +1,5 @@
 <UserControl x:Class="MHWItemBoxTracker.GUI.SettingsTab"
-             xmlns:local="clr-namespace:MHWItemBoxTracker.Config"
+             xmlns:vm="clr-namespace:MHWItemBoxTracker.ViewModels"
              xmlns:src="clr-namespace:HunterPie.GUI;assembly=HunterPie.UI"
              xmlns:Custom="clr-namespace:HunterPie.GUIControls.Custom_Controls;assembly=HunterPie.UI"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
@@ -8,29 +8,33 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              d:DesignHeight="450" d:DesignWidth="800"
              mc:Ignorable="d">
-      <StackPanel>
-        <Custom:Switcher Text="Track items in pouch" />
-        <Custom:Switcher Text="Track items in box" />
-        <Custom:Switcher Text="Track craftable items" />
+  <StackPanel>
+    <Custom:Switcher Text="Track items in pouch" IsEnabled="{Binding TrackPouch, Mode=TwoWay}" />
+    <Custom:Switcher Text="Track items in box" IsEnabled="{Binding TrackBox, Mode=TwoWay}" />
+    <Custom:Switcher Text="Track craftable items" IsEnabled="{Binding TrackCraftable, Mode=TwoWay}" />
 
-        <GroupBox Header="Items to track"
-                  Foreground="WhiteSmoke"
-                  BorderBrush="{x:Null}">
-            <StackPanel>
-              <ListView x:Name="Items2Track">
-                <ListView.ItemTemplate>
-                  <DataTemplate>
-                    <StackPanel Orientation="Horizontal">
-                      <Custom:MinimalButton Text="↕" />
-                      <Custom:ComboBox Label="Item" Width="200" SelectedItem="Red Orb" />
-                      <Custom:TextInput Label="Amount" Width="100" Text="0" />
-                      <Custom:MinimalButton Foreground="Red" Text="✘" />
-                    </StackPanel>
-                  </DataTemplate>
-                </ListView.ItemTemplate>
-              </ListView>
-              <Button Content="Add another" Width="100" HorizontalAlignment="Right" Style="{StaticResource buttons_settings}" />
-            </StackPanel>
-        </GroupBox>
+    <GroupBox Header="Items to track"
+              Foreground="WhiteSmoke"
+              BorderBrush="{x:Null}">
+      <StackPanel>
+        <ListView ItemsSource="{Binding Tracking, Mode=TwoWay}">
+          <ListView.Background>
+            <SolidColorBrush Color="#00000000" Opacity="0"/>
+          </ListView.Background>
+          <ListView.ItemTemplate>
+            <!-- <DataTemplate x:DataType="vm:ItemViewModel"> -->
+            <DataTemplate>
+              <StackPanel Orientation="Horizontal">
+                <Custom:MinimalButton Text="↕" />
+                <Custom:ComboBox Label="Item" Width="200" SelectedItem="Red Orb" />
+                <Custom:TextInput Label="Amount" Width="100" Text="{Binding Amount, Mode=TwoWay}" />
+                <Custom:MinimalButton Foreground="Red" Text="✘" />
+              </StackPanel>
+            </DataTemplate>
+          </ListView.ItemTemplate>
+        </ListView>
+        <Button Content="Add another" Width="100" HorizontalAlignment="Right" Style="{StaticResource buttons_settings}" />
       </StackPanel>
+    </GroupBox>
+  </StackPanel>
 </UserControl>

--- a/ItemBoxTracker/GUI/SettingsTab.xaml
+++ b/ItemBoxTracker/GUI/SettingsTab.xaml
@@ -10,6 +10,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     d:DesignHeight="450"
     d:DesignWidth="800"
+    Loaded="OnLoaded"
     mc:Ignorable="d">
   <UserControl.Resources>
     <ResourceDictionary>

--- a/ItemBoxTracker/GUI/SettingsTab.xaml
+++ b/ItemBoxTracker/GUI/SettingsTab.xaml
@@ -11,6 +11,10 @@
     d:DesignHeight="450"
     d:DesignWidth="800"
     mc:Ignorable="d">
+  <UserControl.Resources>
+    <ResourceDictionary Source="ItemDataTemplate.xaml" />
+  </UserControl.Resources>
+
   <StackPanel>
     <Custom:Switcher
         Text="Track items in pouch"
@@ -38,12 +42,16 @@
           <ListView.ItemTemplate>
             <!-- <DataTemplate x:DataType="vm:ItemViewModel"> -->
             <DataTemplate>
-              <StackPanel Orientation="Horizontal">
+              <StackPanel
+                  Orientation="Horizontal"
+                  x:Name="trackedItem">
                 <Custom:MinimalButton
                     Text="↕"
                     Foreground="#ffbfbfbf" />
                 <local:AutoSuggestBox
                     Placeholder="Search items..."
+                    Selection="{Binding DataContext, ElementName=trackedItem, Mode=TwoWay}"
+                    ItemTemplate="{StaticResource ItemDataTemplate}"
                     Width="250" />
                 <Custom:TextInput
                     Label="Amount"

--- a/ItemBoxTracker/GUI/SettingsTab.xaml
+++ b/ItemBoxTracker/GUI/SettingsTab.xaml
@@ -1,39 +1,66 @@
-<UserControl x:Class="MHWItemBoxTracker.GUI.SettingsTab"
-             xmlns:vm="clr-namespace:MHWItemBoxTracker.ViewModels"
-             xmlns:src="clr-namespace:HunterPie.GUI;assembly=HunterPie.UI"
-             xmlns:Custom="clr-namespace:HunterPie.GUIControls.Custom_Controls;assembly=HunterPie.UI"
-             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             d:DesignHeight="450" d:DesignWidth="800"
-             mc:Ignorable="d">
+<UserControl
+    x:Class="MHWItemBoxTracker.GUI.SettingsTab"
+    xmlns:local="clr-namespace:MHWItemBoxTracker.GUI"
+    xmlns:vm="clr-namespace:MHWItemBoxTracker.ViewModels"
+    xmlns:src="clr-namespace:HunterPie.GUI;assembly=HunterPie.UI"
+    xmlns:Custom="clr-namespace:HunterPie.GUIControls.Custom_Controls;assembly=HunterPie.UI"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    d:DesignHeight="450"
+    d:DesignWidth="800"
+    mc:Ignorable="d">
   <StackPanel>
-    <Custom:Switcher Text="Track items in pouch" IsEnabled="{Binding TrackPouch, Mode=TwoWay}" />
-    <Custom:Switcher Text="Track items in box" IsEnabled="{Binding TrackBox, Mode=TwoWay}" />
-    <Custom:Switcher Text="Track craftable items" IsEnabled="{Binding TrackCraftable, Mode=TwoWay}" />
+    <Custom:Switcher
+        Text="Track items in pouch"
+        IsEnabled="{Binding TrackPouch, Mode=TwoWay}" />
+    <Custom:Switcher
+        Text="Track items in box"
+        IsEnabled="{Binding TrackBox, Mode=TwoWay}" />
+    <Custom:Switcher
+        Text="Track craftable items"
+        IsEnabled="{Binding TrackCraftable, Mode=TwoWay}" />
 
-    <GroupBox Header="Items to track"
-              Foreground="WhiteSmoke"
-              BorderBrush="{x:Null}">
+    <GroupBox
+        Header="Items to track"
+        Foreground="WhiteSmoke"
+        BorderBrush="{x:Null}">
       <StackPanel>
-        <ListView ItemsSource="{Binding Tracking, Mode=TwoWay}">
+        <ListView
+            ItemsSource="{Binding Tracking, Mode=TwoWay}"
+            BorderThickness="0">
           <ListView.Background>
-            <SolidColorBrush Color="#00000000" Opacity="0"/>
+            <SolidColorBrush
+                Color="#00000000"
+                Opacity="0" />
           </ListView.Background>
           <ListView.ItemTemplate>
             <!-- <DataTemplate x:DataType="vm:ItemViewModel"> -->
             <DataTemplate>
               <StackPanel Orientation="Horizontal">
-                <Custom:MinimalButton Text="↕" />
-                <Custom:ComboBox Label="Item" Width="200" SelectedItem="Red Orb" />
-                <Custom:TextInput Label="Amount" Width="100" Text="{Binding Amount, Mode=TwoWay}" />
-                <Custom:MinimalButton Foreground="Red" Text="✘" />
+                <Custom:MinimalButton
+                    Text="↕"
+                    Foreground="#ffbfbfbf" />
+                <local:AutoSuggestBox
+                    Placeholder="Search items..."
+                    Width="250" />
+                <Custom:TextInput
+                    Label="Amount"
+                    Width="100"
+                    Text="{Binding Amount, Mode=TwoWay}" />
+                <Custom:MinimalButton
+                    Foreground="Red"
+                    Text="✘" />
               </StackPanel>
             </DataTemplate>
           </ListView.ItemTemplate>
         </ListView>
-        <Button Content="Add another" Width="100" HorizontalAlignment="Right" Style="{StaticResource buttons_settings}" />
+        <Button
+            Content="Add another"
+            Width="100"
+            HorizontalAlignment="Right"
+            Style="{StaticResource buttons_settings}" />
       </StackPanel>
     </GroupBox>
   </StackPanel>

--- a/ItemBoxTracker/GUI/SettingsTab.xaml
+++ b/ItemBoxTracker/GUI/SettingsTab.xaml
@@ -36,45 +36,47 @@
         Foreground="WhiteSmoke"
         BorderBrush="{x:Null}">
       <StackPanel>
-        <ListView
-            ItemsSource="{Binding Tracking, Mode=TwoWay}"
-            BorderThickness="0">
-          <ListView.Background>
-            <SolidColorBrush
-                Color="#00000000"
-                Opacity="0" />
-          </ListView.Background>
-          <ListView.ItemTemplate>
-            <!-- <DataTemplate x:DataType="vm:ItemViewModel"> -->
-            <DataTemplate>
-              <StackPanel
-                  Orientation="Horizontal"
-                  x:Name="trackedItem">
-                <Custom:MinimalButton
-                    Text="↕"
-                    Foreground="#ffbfbfbf" />
-                <local:AutoSuggestBox
-                    Placeholder="Search items..."
-                    Selection="{Binding DataContext, ElementName=trackedItem, Mode=TwoWay}"
-                    ItemTemplate="{StaticResource ItemDataTemplate}"
-                    OnTextChanged="OnTextChanged"
-                    OnSuggestionChosen="OnSuggestionChosen"
-                    OnClearSelection="OnClearSelection"
-                    Width="250" />
-                <Custom:TextInput
-                    Label="Amount"
-                    Width="100"
-                    Text="{Binding Amount, Mode=TwoWay}" />
-                <Button
-                    Grid.Column='1'
-                    Style="{StaticResource ButtonOverride}"
-                    Foreground="Red"
-                    Click="DeleteRow"
-                    Content="✘" />
-              </StackPanel>
-            </DataTemplate>
-          </ListView.ItemTemplate>
-        </ListView>
+        <local:DragAndDropper>
+          <local:DragAndDropper.Child>
+            <ListView
+                ItemsSource="{Binding Tracking, Mode=TwoWay}"
+                BorderThickness="0">
+              <ListView.Background>
+                <SolidColorBrush
+                    Color="#00000000"
+                    Opacity="0" />
+              </ListView.Background>
+              <ListView.ItemTemplate>
+                <!-- <DataTemplate x:DataType="vm:ItemViewModel"> -->
+                <DataTemplate>
+                  <StackPanel Orientation="Horizontal">
+                    <Custom:MinimalButton
+                        Text="↕"
+                        Foreground="#ffbfbfbf" />
+                    <local:AutoSuggestBox
+                        Placeholder="Search items..."
+                        Selection="{Binding DataContext, RelativeSource={RelativeSource AncestorType=StackPanel}, Mode=TwoWay}"
+                        ItemTemplate="{StaticResource ItemDataTemplate}"
+                        OnTextChanged="OnTextChanged"
+                        OnSuggestionChosen="OnSuggestionChosen"
+                        OnClearSelection="OnClearSelection"
+                        Width="250" />
+                    <Custom:TextInput
+                        Label="Amount"
+                        Width="100"
+                        Text="{Binding Amount, Mode=TwoWay}" />
+                    <Button
+                        Grid.Column='1'
+                        Style="{StaticResource ButtonOverride}"
+                        Foreground="Red"
+                        Click="DeleteRow"
+                        Content="✘" />
+                  </StackPanel>
+                </DataTemplate>
+              </ListView.ItemTemplate>
+            </ListView>
+          </local:DragAndDropper.Child>
+        </local:DragAndDropper>
         <Button
             Content="Add another"
             Width="100"

--- a/ItemBoxTracker/GUI/SettingsTab.xaml.cs
+++ b/ItemBoxTracker/GUI/SettingsTab.xaml.cs
@@ -1,19 +1,8 @@
-using System;
-using System.Diagnostics;
-using System.IO;
-using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Input;
-using System.Windows.Media;
-using MHWItemBoxTracker.Config;
-using MHWItemBoxTracker.ViewModels;
-using static MHWItemBoxTracker.Main;
 
-namespace MHWItemBoxTracker.GUI
-{
+namespace MHWItemBoxTracker.GUI {
   public partial class SettingsTab : UserControl {
-    public SettingsTab() : base()
-    {
+    public SettingsTab() : base() {
       InitializeComponent();
     }
   }

--- a/ItemBoxTracker/GUI/SettingsTab.xaml.cs
+++ b/ItemBoxTracker/GUI/SettingsTab.xaml.cs
@@ -6,6 +6,7 @@ using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Media;
 using MHWItemBoxTracker.Config;
+using MHWItemBoxTracker.ViewModels;
 using static MHWItemBoxTracker.Main;
 
 namespace MHWItemBoxTracker.GUI
@@ -18,10 +19,10 @@ namespace MHWItemBoxTracker.GUI
     }
 
     public static new readonly DependencyProperty ContextProperty =
-      DependencyProperty.Register("Context", typeof(TrackingTabConfig), typeof(SettingsTab));
-    public new TrackingTabConfig Context
+      DependencyProperty.Register("Context", typeof(TrackingTabViewModel), typeof(SettingsTab));
+    public new TrackingTabViewModel Context
     {
-      get => (TrackingTabConfig)GetValue(ContextProperty);
+      get => (TrackingTabViewModel)GetValue(ContextProperty);
       set => SetValue(ContextProperty, value);
     }
 

--- a/ItemBoxTracker/GUI/SettingsTab.xaml.cs
+++ b/ItemBoxTracker/GUI/SettingsTab.xaml.cs
@@ -1,6 +1,12 @@
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Windows;
 using System.Windows.Controls;
+using HunterPie.Plugins;
+using MHWItemBoxTracker.Config;
 using MHWItemBoxTracker.ViewModels;
+using Newtonsoft.Json;
+using static MHWItemBoxTracker.Main;
 
 namespace MHWItemBoxTracker.GUI {
   public partial class SettingsTab : UserControl {
@@ -14,6 +20,21 @@ namespace MHWItemBoxTracker.GUI {
     }
     private void AddRow(object sender, RoutedEventArgs e) {
       ((TrackingTabViewModel)DataContext).Tracking.Add(new ItemViewModel());
+    }
+
+    private void OnTextChanged(ObservableCollection<object> suggestions, string input) {
+      // TODO: Filter items from HunterPie
+      suggestions.Clear();
+    }
+    private void OnSuggestionChosen(object selection, object choice) {
+      var Selection = (ItemViewModel)selection;
+      var Choice = (ItemViewModel)choice;
+      Selection.ItemId = Choice.ItemId;
+      Selection.Name = Choice.Name;
+    }
+    private void OnClearSelection(object selection) {
+      var Selection = (ItemViewModel)selection;
+      Selection.ItemId = 0;
     }
   }
 }

--- a/ItemBoxTracker/GUI/SettingsTab.xaml.cs
+++ b/ItemBoxTracker/GUI/SettingsTab.xaml.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Globalization;
@@ -13,24 +14,8 @@ using static MHWItemBoxTracker.Main;
 
 namespace MHWItemBoxTracker.GUI {
   public partial class SettingsTab : UserControl {
-    private List<ItemViewModel> Items = new();
-
     public SettingsTab() : base() {
       InitializeComponent();
-    }
-
-    private void OnLoaded(object sender, RoutedEventArgs e) {
-      LoadItems();
-    }
-
-    private void LoadItems() {
-      Items = Enumerable
-        .Range(0, GMD.Items.gValuesOffsets.Length)
-        .Select(id => new ItemViewModel {
-          ItemId = id,
-          Name = GMD.GetItemNameById(id)
-        })
-        .ToList();
     }
 
     private void DeleteRow(object sender, RoutedEventArgs e) {
@@ -63,12 +48,14 @@ namespace MHWItemBoxTracker.GUI {
     }
 
     private void OnTextChanged(ObservableCollection<object> suggestions, string input) {
-      var Tracking = ((TrackingTabViewModel)DataContext).Tracking;
-      var items = Items
+      var DC = DataContext as TrackingTabViewModel;
+      Plugin.Log($"{DC.Items}");
+      Plugin.Log($"{DC.Items.Count}");
+      var items = DC.Items
         .Where(
           item => CultureInfo.CurrentCulture.CompareInfo
             .IndexOf(item.Name, input, CompareOptions.IgnoreCase) >= 0)
-        .Where(item => !Tracking.Contains(item));
+        .Where(item => !DC.Tracking.Contains(item));
 
       suggestions.Clear();
       foreach (var item in items) {

--- a/ItemBoxTracker/GUI/SettingsTab.xaml.cs
+++ b/ItemBoxTracker/GUI/SettingsTab.xaml.cs
@@ -16,14 +16,36 @@ namespace MHWItemBoxTracker.GUI {
 
     private void DeleteRow(object sender, RoutedEventArgs e) {
       var item = ((FrameworkElement)sender).DataContext as ItemViewModel;
-      ((TrackingTabViewModel)DataContext).Tracking.Remove(item);
+      var Tracking = ((TrackingTabViewModel)DataContext).Tracking;
+      Tracking.Remove(item);
+      if (Tracking.Count == 0) {
+        Tracking.Add(new ItemViewModel());
+      }
     }
     private void AddRow(object sender, RoutedEventArgs e) {
       ((TrackingTabViewModel)DataContext).Tracking.Add(new ItemViewModel());
     }
+    private void MoveUp(object sender, RoutedEventArgs e) {
+      var item = ((FrameworkElement)sender).DataContext as ItemViewModel;
+      var Tracking = ((TrackingTabViewModel)DataContext).Tracking;
+      var index = Tracking.IndexOf(item);
+      if (index > 0) {
+        Tracking.Move(index, index - 1);
+      }
+    }
+
+    private void MoveDown(object sender, RoutedEventArgs e) {
+      var item = ((FrameworkElement)sender).DataContext as ItemViewModel;
+      var Tracking = ((TrackingTabViewModel)DataContext).Tracking;
+      var index = Tracking.IndexOf(item);
+      if (index < Tracking.Count - 1) {
+        Tracking.Move(index, index + 1);
+      }
+    }
 
     private void OnTextChanged(ObservableCollection<object> suggestions, string input) {
-      // TODO: Filter items from HunterPie
+      // TODO: Filter items from HunterPie based on search
+      // filter out items already in ((TrackingTabViewModel)DataContext).Tracking
       suggestions.Clear();
     }
     private void OnSuggestionChosen(object selection, object choice) {

--- a/ItemBoxTracker/GUI/SettingsTab.xaml.cs
+++ b/ItemBoxTracker/GUI/SettingsTab.xaml.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Media;
+using MHWItemBoxTracker.Config;
+using static MHWItemBoxTracker.Main;
+
+namespace MHWItemBoxTracker.GUI
+{
+  public partial class SettingsTab : UserControl {
+    public SettingsTab()
+    {
+      InitializeComponent();
+      Items2Track.ItemsSource = Context.Tracking;
+    }
+
+    public static new readonly DependencyProperty ContextProperty =
+      DependencyProperty.Register("Context", typeof(TrackingTabConfig), typeof(SettingsTab));
+    public new TrackingTabConfig Context
+    {
+      get => (TrackingTabConfig)GetValue(ContextProperty);
+      set => SetValue(ContextProperty, value);
+    }
+
+
+  }
+}

--- a/ItemBoxTracker/GUI/SettingsTab.xaml.cs
+++ b/ItemBoxTracker/GUI/SettingsTab.xaml.cs
@@ -1,16 +1,9 @@
-using System.Collections;
-using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Globalization;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
-using HunterPie.Core.Native;
-using HunterPie.Plugins;
-using HunterPie.Utils;
 using MHWItemBoxTracker.ViewModels;
-using Newtonsoft.Json;
-using static MHWItemBoxTracker.Main;
 
 namespace MHWItemBoxTracker.GUI {
   public partial class SettingsTab : UserControl {
@@ -49,8 +42,6 @@ namespace MHWItemBoxTracker.GUI {
 
     private void OnTextChanged(ObservableCollection<object> suggestions, string input) {
       var DC = DataContext as TrackingTabViewModel;
-      Plugin.Log($"{DC.Items}");
-      Plugin.Log($"{DC.Items.Count}");
       var items = DC.Items
         .Where(
           item => CultureInfo.CurrentCulture.CompareInfo

--- a/ItemBoxTracker/GUI/SettingsTab.xaml.cs
+++ b/ItemBoxTracker/GUI/SettingsTab.xaml.cs
@@ -1,9 +1,19 @@
+using System.Windows;
 using System.Windows.Controls;
+using MHWItemBoxTracker.ViewModels;
 
 namespace MHWItemBoxTracker.GUI {
   public partial class SettingsTab : UserControl {
     public SettingsTab() : base() {
       InitializeComponent();
+    }
+
+    private void DeleteRow(object sender, RoutedEventArgs e) {
+      var item = ((FrameworkElement)sender).DataContext as ItemViewModel;
+      ((TrackingTabViewModel)DataContext).Tracking.Remove(item);
+    }
+    private void AddRow(object sender, RoutedEventArgs e) {
+      ((TrackingTabViewModel)DataContext).Tracking.Add(new ItemViewModel());
     }
   }
 }

--- a/ItemBoxTracker/GUI/SettingsTab.xaml.cs
+++ b/ItemBoxTracker/GUI/SettingsTab.xaml.cs
@@ -12,20 +12,9 @@ using static MHWItemBoxTracker.Main;
 namespace MHWItemBoxTracker.GUI
 {
   public partial class SettingsTab : UserControl {
-    public SettingsTab()
+    public SettingsTab() : base()
     {
       InitializeComponent();
-      Items2Track.ItemsSource = Context.Tracking;
     }
-
-    public static new readonly DependencyProperty ContextProperty =
-      DependencyProperty.Register("Context", typeof(TrackingTabViewModel), typeof(SettingsTab));
-    public new TrackingTabViewModel Context
-    {
-      get => (TrackingTabViewModel)GetValue(ContextProperty);
-      set => SetValue(ContextProperty, value);
-    }
-
-
   }
 }

--- a/ItemBoxTracker/ItemBoxTracker.csproj
+++ b/ItemBoxTracker/ItemBoxTracker.csproj
@@ -105,6 +105,9 @@
     <Compile Include="Config\ItemBoxWidgetSettings.cs" />
     <Compile Include="Config\ItemConfig.cs" />
     <Compile Include="Config\TrackingTabConfig.cs" />
+    <Compile Include="GUI\AutoSuggestBox.xaml.cs">
+      <DependentUpon>AutoSuggestBox.xaml</DependentUpon>
+    </Compile>
     <Compile Include="GUI\ItemBoxTracker.xaml.cs">
       <DependentUpon>ItemBoxTracker.xaml</DependentUpon>
     </Compile>
@@ -147,6 +150,10 @@
   </ItemGroup>
   <ItemGroup />
   <ItemGroup>
+    <Page Include="GUI\AutoSuggestBox.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="GUI\ItemBoxTracker.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>

--- a/ItemBoxTracker/ItemBoxTracker.csproj
+++ b/ItemBoxTracker/ItemBoxTracker.csproj
@@ -108,6 +108,9 @@
     <Compile Include="GUI\AutoSuggestBox.xaml.cs">
       <DependentUpon>AutoSuggestBox.xaml</DependentUpon>
     </Compile>
+    <Compile Include="GUI\DragAndDropper.xaml.cs">
+      <DependentUpon>DragAndDropper.xaml</DependentUpon>
+    </Compile>
     <Compile Include="GUI\ItemBoxTracker.xaml.cs">
       <DependentUpon>ItemBoxTracker.xaml</DependentUpon>
     </Compile>
@@ -151,6 +154,10 @@
   <ItemGroup />
   <ItemGroup>
     <Page Include="GUI\AutoSuggestBox.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="GUI\DragAndDropper.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/ItemBoxTracker/ItemBoxTracker.csproj
+++ b/ItemBoxTracker/ItemBoxTracker.csproj
@@ -121,6 +121,11 @@
     </Compile>
     <Compile Include="Utils\Dispatcher.cs" />
     <Compile Include="Utils\JsonSchema.cs" />
+    <Compile Include="Utils\NotifyPropertyChanged.cs" />
+    
+    <Compile Include="ViewModels\ItemBoxTrackerViewModel.cs" />
+    <Compile Include="ViewModels\ItemViewModel.cs" />
+    <Compile Include="ViewModels\TrackingTabViewModel.cs" />
     <EmbeddedResource Include="Properties\Resources.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>

--- a/ItemBoxTracker/ItemBoxTracker.csproj
+++ b/ItemBoxTracker/ItemBoxTracker.csproj
@@ -158,6 +158,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="GUI\ItemDataTemplate.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="GUI\Settings.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>

--- a/ItemBoxTracker/ItemBoxTracker.csproj
+++ b/ItemBoxTracker/ItemBoxTracker.csproj
@@ -154,6 +154,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="GUI\ButtonOverride.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="GUI\ItemBoxTracker.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>

--- a/ItemBoxTracker/ItemBoxTracker.csproj
+++ b/ItemBoxTracker/ItemBoxTracker.csproj
@@ -101,6 +101,9 @@
     <Compile Include="GUI\Settings.xaml.cs">
       <DependentUpon>Settings.xaml</DependentUpon>
     </Compile>
+    <Compile Include="GUI\SettingsTab.xaml.cs">
+      <DependentUpon>SettingsTab.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Controller\ItemBoxTracker.cs" />
     <Compile Include="Main.cs" />
     <Compile Include="Properties\AssemblyInfo.cs">
@@ -134,6 +137,10 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="GUI\Settings.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="GUI\SettingsTab.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/ItemBoxTracker/ItemBoxTracker.csproj
+++ b/ItemBoxTracker/ItemBoxTracker.csproj
@@ -98,13 +98,57 @@
     <!-- <Reference Include="..\HunterPie.UI.dll" /> -->
   </ItemGroup>
 
-  <!-- csproj BS -->
+  <!-- BS that never gets touched -->
   <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="Properties\Resources.Designer.cs">
+      <AutoGen>True</AutoGen>
+      <DesignTime>True</DesignTime>
+      <DependentUpon>Resources.resx</DependentUpon>
+    </Compile>
+    <Compile Include="Properties\Settings.Designer.cs">
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Settings.settings</DependentUpon>
+      <DesignTimeSharedInput>True</DesignTimeSharedInput>
+    </Compile>
+    <EmbeddedResource Include="Properties\Resources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>Resources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+    <None Include="Properties\Settings.settings">
+      <Generator>SettingsSingleFileGenerator</Generator>
+      <LastGenOutput>Settings.Designer.cs</LastGenOutput>
+    </None>
+  </ItemGroup>
+
+  <!-- BS source file list -->
+  <ItemGroup>
+    <Compile Include="Main.cs" />
+
     <Compile Include="Config\DeprecatedItemBoxTrackerConfig.cs" />
     <Compile Include="Config\ItemBoxTrackerConfig.cs" />
     <Compile Include="Config\ItemBoxWidgetSettings.cs" />
     <Compile Include="Config\ItemConfig.cs" />
     <Compile Include="Config\TrackingTabConfig.cs" />
+
+    <Compile Include="Controller\ItemBoxTracker.cs" />
+
+    <Compile Include="Service\ConfigService.cs" />
+
+    <Compile Include="Utils\Dispatcher.cs" />
+    <Compile Include="Utils\JsonSchema.cs" />
+    <Compile Include="Utils\NotifyPropertyChanged.cs" />
+
+    <Compile Include="ViewModels\ItemBoxTrackerViewModel.cs" />
+    <Compile Include="ViewModels\ItemViewModel.cs" />
+    <Compile Include="ViewModels\TrackingTabViewModel.cs" />
+
+  </ItemGroup>
+
+  <!-- XAML Code-Behind -->
+  <ItemGroup>
     <Compile Include="GUI\AutoSuggestBox.xaml.cs">
       <DependentUpon>AutoSuggestBox.xaml</DependentUpon>
     </Compile>
@@ -120,44 +164,11 @@
     <Compile Include="GUI\SettingsTab.xaml.cs">
       <DependentUpon>SettingsTab.xaml</DependentUpon>
     </Compile>
-    <Compile Include="Controller\ItemBoxTracker.cs" />
-    <Compile Include="Main.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Properties\Resources.Designer.cs">
-      <AutoGen>True</AutoGen>
-      <DesignTime>True</DesignTime>
-      <DependentUpon>Resources.resx</DependentUpon>
-    </Compile>
-    <Compile Include="Properties\Settings.Designer.cs">
-      <AutoGen>True</AutoGen>
-      <DependentUpon>Settings.settings</DependentUpon>
-      <DesignTimeSharedInput>True</DesignTimeSharedInput>
-    </Compile>
-    <Compile Include="Utils\Dispatcher.cs" />
-    <Compile Include="Utils\JsonSchema.cs" />
-    <Compile Include="Utils\NotifyPropertyChanged.cs" />
-
-    <Compile Include="ViewModels\ItemBoxTrackerViewModel.cs" />
-    <Compile Include="ViewModels\ItemViewModel.cs" />
-    <Compile Include="ViewModels\TrackingTabViewModel.cs" />
-    <EmbeddedResource Include="Properties\Resources.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
-      <LastGenOutput>Resources.Designer.cs</LastGenOutput>
-    </EmbeddedResource>
-    <None Include="Properties\Settings.settings">
-      <Generator>SettingsSingleFileGenerator</Generator>
-      <LastGenOutput>Settings.Designer.cs</LastGenOutput>
-    </None>
   </ItemGroup>
-  <ItemGroup />
+
+  <!-- XAML -->
   <ItemGroup>
     <Page Include="GUI\AutoSuggestBox.xaml">
-      <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
-    </Page>
-    <Page Include="GUI\DragAndDropper.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
@@ -165,11 +176,15 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
-    <Page Include="GUI\ItemBoxTracker.xaml">
+    <Page Include="GUI\DragAndDropper.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="GUI\ItemDataTemplate.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="GUI\ItemBoxTracker.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/ItemBoxTracker/ItemBoxTracker.csproj
+++ b/ItemBoxTracker/ItemBoxTracker.csproj
@@ -1,7 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-  
+<Project
+    ToolsVersion="15.0"
+    xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import
+      Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props"
+      Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+
   <!-- Build Configs -->
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -72,7 +76,9 @@
 
   <!-- Build tools -->
   <ItemGroup>
-    <PackageReference Include="MSBuild.AssemblyVersion" Version="1.3.0">
+    <PackageReference
+        Include="MSBuild.AssemblyVersion"
+        Version="1.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
@@ -80,8 +86,12 @@
 
   <!-- Nuget OR Local DLLs -->
   <ItemGroup>
-    <PackageReference Include="HunterPie.Core" Version="1.0.8" />
-    <PackageReference Include="HunterPie.UI" Version="1.0.18" />
+    <PackageReference
+        Include="HunterPie.Core"
+        Version="1.0.8" />
+    <PackageReference
+        Include="HunterPie.UI"
+        Version="1.0.18" />
     <!-- <PackageReference Include="HunterPie.Core" Version="0.0.0" /> -->
     <!-- <PackageReference Include="HunterPie.UI" Version="0.0.0" /> -->
     <!-- <Reference Include="..\HunterPie.Core.dll" /> -->
@@ -122,7 +132,7 @@
     <Compile Include="Utils\Dispatcher.cs" />
     <Compile Include="Utils\JsonSchema.cs" />
     <Compile Include="Utils\NotifyPropertyChanged.cs" />
-    
+
     <Compile Include="ViewModels\ItemBoxTrackerViewModel.cs" />
     <Compile Include="ViewModels\ItemViewModel.cs" />
     <Compile Include="ViewModels\TrackingTabViewModel.cs" />
@@ -153,7 +163,7 @@
 
   <!-- Targets (Our targets need to be declared after imports) -->
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Target Name = "Clean">
+  <Target Name="Clean">
     <RemoveDir Directories="obj;bin" />
   </Target>
 </Project>

--- a/ItemBoxTracker/ItemBoxTracker.csproj
+++ b/ItemBoxTracker/ItemBoxTracker.csproj
@@ -135,6 +135,8 @@
 
     <Compile Include="Controller\ItemBoxTracker.cs" />
 
+    <Compile Include="Converter\ItemIdToDescription.cs" />
+
     <Compile Include="Service\ConfigService.cs" />
 
     <Compile Include="Utils\Dispatcher.cs" />

--- a/ItemBoxTracker/Main.cs
+++ b/ItemBoxTracker/Main.cs
@@ -2,71 +2,63 @@
 
 using HunterPie.Core;
 using HunterPie.Plugins;
-using MHWItemBoxTracker;
-using MHWItemBoxTracker.Utils;
 using HunterPie.Settings;
 using static MHWItemBoxTracker.Utils.Dispatcher;
 
-namespace MHWItemBoxTracker
-{
-    public class Main : IPlugin, ISettingsOwner
-    {
-        public string Name { get; set; }
-        public string Description { get; set; }
-        public Game Context { get; set; }
-        private Controller.ItemBoxTracker tracker { get; set; }
+namespace MHWItemBoxTracker {
+  public class Main : IPlugin, ISettingsOwner {
+    public string Name { get; set; }
+    public string Description { get; set; }
+    public Game Context { get; set; }
+    private Controller.ItemBoxTracker tracker { get; set; }
 
-        // Really bad singleton, but I think it's fine considering
-        // the plugin gets instantiated by HunterPie
-        // and everywhere that uses the singleton is part of this plugin
-        // i.e. plugin is guarenteed to be instantiated
-        private static Main instance = null;
-        public static Main Plugin => instance;
+    // Really bad singleton, but I think it's fine considering
+    // the plugin gets instantiated by HunterPie
+    // and everywhere that uses the singleton is part of this plugin
+    // i.e. plugin is guarenteed to be instantiated
+    private static Main instance = null;
+    public static Main Plugin => instance;
 
-        public Main() {
-            instance = this;
-        }
-
-        public void Initialize(Game context)
-        {
-            Dispatch(async () => {
-                var module = await this.LoadJson<PluginInformation>("module.json");
-                Name = module.Name;
-                Description = module.Description;
-            });
-            Context = context;
-
-            tracker = new Controller.ItemBoxTracker(context.Player);
-            hookEvents();
-        }
-
-        public void Unload()
-        {
-            unhookEvents();
-            tracker.unregister();
-        }
-
-        internal void hookEvents()
-        {
-            var player = Context.Player;
-            player.OnVillageEnter += tracker.loadItemBox;
-            player.OnVillageLeave += tracker.unloadItemBox;
-            player.ItemBox.OnItemBoxUpdate += tracker.loadItemBox;
-        }
-
-        internal void unhookEvents()
-        {
-            var player = Context.Player;
-            player.OnVillageEnter -= tracker.loadItemBox;
-            player.OnVillageLeave -= tracker.unloadItemBox;
-            player.ItemBox.OnItemBoxUpdate -= tracker.loadItemBox;
-
-            tracker.unloadItemBox();
-        }
-
-        public IEnumerable<ISettingsTab> GetSettings(ISettingsBuilder builder) {
-            builder.AddTab(new GUI.Settings());
-            return builder.Value();
-        }
+    public Main() {
+      instance = this;
     }
+
+    public void Initialize(Game context) {
+      Dispatch(async () => {
+        var module = await this.LoadJson<PluginInformation>("module.json");
+        Name = module.Name;
+        Description = module.Description;
+      });
+      Context = context;
+
+      tracker = new Controller.ItemBoxTracker(context.Player);
+      hookEvents();
+    }
+
+    public void Unload() {
+      unhookEvents();
+      tracker.unregister();
+    }
+
+    internal void hookEvents() {
+      var player = Context.Player;
+      player.OnVillageEnter += tracker.loadItemBox;
+      player.OnVillageLeave += tracker.unloadItemBox;
+      player.ItemBox.OnItemBoxUpdate += tracker.loadItemBox;
+    }
+
+    internal void unhookEvents() {
+      var player = Context.Player;
+      player.OnVillageEnter -= tracker.loadItemBox;
+      player.OnVillageLeave -= tracker.unloadItemBox;
+      player.ItemBox.OnItemBoxUpdate -= tracker.loadItemBox;
+
+      tracker.unloadItemBox();
+    }
+
+    public IEnumerable<ISettingsTab> GetSettings(ISettingsBuilder builder) {
+      builder.AddTab(new GUI.Settings());
+      return builder.Value();
+    }
+  }
 }

--- a/ItemBoxTracker/Main.cs
+++ b/ItemBoxTracker/Main.cs
@@ -4,6 +4,7 @@ using HunterPie.Core;
 using HunterPie.Plugins;
 using HunterPie.Settings;
 using MHWItemBoxTracker.Config;
+using MHWItemBoxTracker.Service;
 using static MHWItemBoxTracker.Utils.Dispatcher;
 
 namespace MHWItemBoxTracker {
@@ -12,7 +13,7 @@ namespace MHWItemBoxTracker {
     public string Description { get; set; }
     public Game Context { get; set; }
 
-    public ItemBoxTrackerConfig Config { get; set; }
+    private ConfigService Config = new();
     private Controller.ItemBoxTracker tracker { get; set; }
 
     public static string settings = "settings.json";
@@ -25,20 +26,15 @@ namespace MHWItemBoxTracker {
 
     public Main() {
       instance = this;
-      Dispatch(async () => {
-        Config = await this.LoadJson<ItemBoxTrackerConfig>(settings);
-      });
     }
 
-    public void Initialize(Game context) {
-      Dispatch(async () => {
-        var module = await this.LoadJson<PluginInformation>("module.json");
-        Name = module.Name;
-        Description = module.Description;
-      });
+    public async void Initialize(Game context) {
+      var module = await this.LoadJson<PluginInformation>("module.json");
+      Name = module.Name;
+      Description = module.Description;
       Context = context;
 
-      tracker = new Controller.ItemBoxTracker(context.Player);
+      tracker = new Controller.ItemBoxTracker(context.Player, Config);
       hookEvents();
     }
 
@@ -64,7 +60,7 @@ namespace MHWItemBoxTracker {
     }
 
     public IEnumerable<ISettingsTab> GetSettings(ISettingsBuilder builder) {
-      builder.AddTab(new GUI.Settings());
+      builder.AddTab(new GUI.Settings(Config));
       return builder.Value();
     }
   }

--- a/ItemBoxTracker/Main.cs
+++ b/ItemBoxTracker/Main.cs
@@ -1,11 +1,8 @@
 ﻿using System.Collections.Generic;
-
 using HunterPie.Core;
 using HunterPie.Plugins;
 using HunterPie.Settings;
-using MHWItemBoxTracker.Config;
 using MHWItemBoxTracker.Service;
-using static MHWItemBoxTracker.Utils.Dispatcher;
 
 namespace MHWItemBoxTracker {
   public class Main : IPlugin, ISettingsOwner {
@@ -16,7 +13,6 @@ namespace MHWItemBoxTracker {
     private ConfigService Config = new();
     private Controller.ItemBoxTracker tracker { get; set; }
 
-    public static string settings = "settings.json";
     // Really bad singleton, but I think it's fine considering
     // the plugin gets instantiated by HunterPie
     // and everywhere that uses the singleton is part of this plugin

--- a/ItemBoxTracker/Main.cs
+++ b/ItemBoxTracker/Main.cs
@@ -3,6 +3,7 @@
 using HunterPie.Core;
 using HunterPie.Plugins;
 using HunterPie.Settings;
+using MHWItemBoxTracker.Config;
 using static MHWItemBoxTracker.Utils.Dispatcher;
 
 namespace MHWItemBoxTracker {
@@ -10,8 +11,11 @@ namespace MHWItemBoxTracker {
     public string Name { get; set; }
     public string Description { get; set; }
     public Game Context { get; set; }
+
+    public ItemBoxTrackerConfig Config { get; set; }
     private Controller.ItemBoxTracker tracker { get; set; }
 
+    public static string settings = "settings.json";
     // Really bad singleton, but I think it's fine considering
     // the plugin gets instantiated by HunterPie
     // and everywhere that uses the singleton is part of this plugin
@@ -21,6 +25,9 @@ namespace MHWItemBoxTracker {
 
     public Main() {
       instance = this;
+      Dispatch(async () => {
+        Config = await this.LoadJson<ItemBoxTrackerConfig>(settings);
+      });
     }
 
     public void Initialize(Game context) {

--- a/ItemBoxTracker/Service/ConfigService.cs
+++ b/ItemBoxTracker/Service/ConfigService.cs
@@ -22,6 +22,7 @@ namespace MHWItemBoxTracker.Service {
           if (oldConfig.Tracking.Count > 0) {
             config.Always.Tracking = oldConfig.Tracking.ToList();
             await Plugin.SaveJson(settings, config);
+            Plugin.Log("Converted settings file to the new format");
           }
           Config = config;
         }

--- a/ItemBoxTracker/Service/ConfigService.cs
+++ b/ItemBoxTracker/Service/ConfigService.cs
@@ -1,0 +1,45 @@
+
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using HunterPie.Plugins;
+using MHWItemBoxTracker.Config;
+using static MHWItemBoxTracker.Main;
+
+namespace MHWItemBoxTracker.Service {
+  public class ConfigService {
+    public static string settings = "settings.json";
+    private static readonly SemaphoreSlim locke = new(1, 1);
+    private ItemBoxTrackerConfig Config;
+
+    public async Task<ItemBoxTrackerConfig> LoadAsync() {
+      await locke.WaitAsync();
+      try {
+        if (Config == null) {
+          var config = await Plugin.LoadJson<ItemBoxTrackerConfig>(settings);
+          // Not writing a comparer just for this...
+          var oldConfig = await Plugin.LoadJson<DeprecatedItemBoxTrackerConfig>(settings);
+          if (oldConfig.Tracking.Count > 0) {
+            config.Always.Tracking = oldConfig.Tracking.ToList();
+            await Plugin.SaveJson(settings, config);
+          }
+          Config = config;
+        }
+
+        return Config;
+      } finally {
+        locke.Release();
+      }
+    }
+
+    public async Task SaveAsync(ItemBoxTrackerConfig config) {
+      await locke.WaitAsync();
+      try {
+        Config = config;
+        await Plugin.SaveJson(settings, Config);
+      } finally {
+        locke.Release();
+      }
+    }
+  }
+}

--- a/ItemBoxTracker/Utils/Dispatcher.cs
+++ b/ItemBoxTracker/Utils/Dispatcher.cs
@@ -1,10 +1,6 @@
-using System;
-
-namespace MHWItemBoxTracker.Utils
-{
-    public class Dispatcher
-    {
-        public static void Dispatch(System.Action function) =>
-            System.Windows.Application.Current.Dispatcher.BeginInvoke(System.Windows.Threading.DispatcherPriority.Render, function);
-    }
+namespace MHWItemBoxTracker.Utils {
+  public class Dispatcher {
+    public static void Dispatch(System.Action function) =>
+        System.Windows.Application.Current.Dispatcher.BeginInvoke(System.Windows.Threading.DispatcherPriority.Render, function);
+  }
 }

--- a/ItemBoxTracker/Utils/JsonSchema.cs
+++ b/ItemBoxTracker/Utils/JsonSchema.cs
@@ -1,16 +1,14 @@
 ﻿using Newtonsoft.Json;
 using Newtonsoft.Json.Schema.Generation;
 
-namespace MHWItemBoxTracker.Utils
-{
-    public class JsonSchema
-    {
-        public static string Generate<T>()
-        {
-            var generator = new JSchemaGenerator();
-            generator.DefaultRequired = Required.DisallowNull;
-            var json = generator.Generate(typeof(T));
-            return json.ToString();
-        }
+namespace MHWItemBoxTracker.Utils {
+  public class JsonSchema {
+    public static string Generate<T>() {
+      var generator = new JSchemaGenerator {
+        DefaultRequired = Required.DisallowNull
+      };
+      var json = generator.Generate(typeof(T));
+      return json.ToString();
     }
+  }
 }

--- a/ItemBoxTracker/Utils/NotifyPropertyChanged.cs
+++ b/ItemBoxTracker/Utils/NotifyPropertyChanged.cs
@@ -6,7 +6,7 @@ namespace MHWItemBoxTracker.Utils {
 
   public class NotifyPropertyChanged : INotifyPropertyChanged {
     public event PropertyChangedEventHandler PropertyChanged;
-    protected void OnPropertyChanged(string propertyName) => PropertyChanged.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    protected void OnPropertyChanged(string propertyName) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
 
     protected bool SetField<T>(ref T field, T value, [CallerMemberName] string propertyName = null) {
       if (EqualityComparer<T>.Default.Equals(field, value)) return false;

--- a/ItemBoxTracker/Utils/NotifyPropertyChanged.cs
+++ b/ItemBoxTracker/Utils/NotifyPropertyChanged.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace MHWItemBoxTracker.Utils {
+
+  public class NotifyPropertyChanged : INotifyPropertyChanged {
+    public event PropertyChangedEventHandler PropertyChanged;
+    protected void OnPropertyChanged(string propertyName) => PropertyChanged.Invoke(this, new PropertyChangedEventArgs(propertyName));
+
+    protected bool SetField<T>(ref T field, T value, [CallerMemberName] string propertyName = null) {
+      if (EqualityComparer<T>.Default.Equals(field, value)) return false;
+      field = value;
+      OnPropertyChanged(propertyName);
+      return true;
+    }
+  }
+}

--- a/ItemBoxTracker/ViewModels/ItemBoxTrackerViewModel.cs
+++ b/ItemBoxTracker/ViewModels/ItemBoxTrackerViewModel.cs
@@ -1,0 +1,45 @@
+﻿using System.Collections.Generic;
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+using HunterPie.Plugins;
+using MHWItemBoxTracker.Config;
+using MHWItemBoxTracker.Utils;
+
+namespace MHWItemBoxTracker.ViewModels
+{
+  public class ItemBoxTrackerViewModel : NotifyPropertyChanged
+  {
+    private TrackingTabViewModel always;
+    private TrackingTabViewModel village;
+    private TrackingTabViewModel quest;
+
+    public ItemBoxTrackerViewModel(ItemBoxTrackerConfig config) {
+      always = new TrackingTabViewModel(config.Always);
+      village = new TrackingTabViewModel(config.Village);
+      quest = new TrackingTabViewModel(config.Quest);
+    }
+    
+    public TrackingTabViewModel Always {
+      get => always;
+      set => SetField(ref always, value);
+    }
+    
+    public TrackingTabViewModel Village {
+      get => village;
+      set => SetField(ref village, value);
+    }
+    
+    public TrackingTabViewModel Quest {
+      get => quest;
+      set => SetField(ref quest, value);
+    }
+
+    public ItemBoxTrackerConfig ToConfig() {
+      var config = new ItemBoxTrackerConfig();
+      config.Always = always.ToConfig();
+      config.Village = village.ToConfig();
+      config.Quest = quest.ToConfig();
+      return config;
+    }
+  }
+}

--- a/ItemBoxTracker/ViewModels/ItemBoxTrackerViewModel.cs
+++ b/ItemBoxTracker/ViewModels/ItemBoxTrackerViewModel.cs
@@ -1,4 +1,5 @@
-﻿using MHWItemBoxTracker.Config;
+﻿using System.Collections.ObjectModel;
+using MHWItemBoxTracker.Config;
 using MHWItemBoxTracker.Utils;
 
 namespace MHWItemBoxTracker.ViewModels {
@@ -6,11 +7,18 @@ namespace MHWItemBoxTracker.ViewModels {
     private TrackingTabViewModel always;
     private TrackingTabViewModel village;
     private TrackingTabViewModel quest;
+    private ObservableCollection<ItemViewModel> items = new();
 
     public ItemBoxTrackerViewModel(ItemBoxTrackerConfig config) {
-      always = new TrackingTabViewModel(config.Always);
-      village = new TrackingTabViewModel(config.Village);
-      quest = new TrackingTabViewModel(config.Quest);
+      always = new TrackingTabViewModel(config.Always) {
+        Items = Items
+      };
+      village = new TrackingTabViewModel(config.Village) {
+        Items = Items
+      };
+      quest = new TrackingTabViewModel(config.Quest) {
+        Items = Items
+      };
     }
 
     public TrackingTabViewModel Always {
@@ -26,6 +34,11 @@ namespace MHWItemBoxTracker.ViewModels {
     public TrackingTabViewModel Quest {
       get => quest;
       set => SetField(ref quest, value);
+    }
+
+    public ObservableCollection<ItemViewModel> Items {
+      get => items;
+      set => SetField(ref items, value);
     }
 
     public ItemBoxTrackerConfig ToConfig() {

--- a/ItemBoxTracker/ViewModels/ItemBoxTrackerViewModel.cs
+++ b/ItemBoxTracker/ViewModels/ItemBoxTrackerViewModel.cs
@@ -1,14 +1,8 @@
-﻿using System.Collections.Generic;
-using System.ComponentModel;
-using System.ComponentModel.DataAnnotations;
-using HunterPie.Plugins;
-using MHWItemBoxTracker.Config;
+﻿using MHWItemBoxTracker.Config;
 using MHWItemBoxTracker.Utils;
 
-namespace MHWItemBoxTracker.ViewModels
-{
-  public class ItemBoxTrackerViewModel : NotifyPropertyChanged
-  {
+namespace MHWItemBoxTracker.ViewModels {
+  public class ItemBoxTrackerViewModel : NotifyPropertyChanged {
     private TrackingTabViewModel always;
     private TrackingTabViewModel village;
     private TrackingTabViewModel quest;
@@ -18,28 +12,28 @@ namespace MHWItemBoxTracker.ViewModels
       village = new TrackingTabViewModel(config.Village);
       quest = new TrackingTabViewModel(config.Quest);
     }
-    
+
     public TrackingTabViewModel Always {
       get => always;
       set => SetField(ref always, value);
     }
-    
+
     public TrackingTabViewModel Village {
       get => village;
       set => SetField(ref village, value);
     }
-    
+
     public TrackingTabViewModel Quest {
       get => quest;
       set => SetField(ref quest, value);
     }
 
     public ItemBoxTrackerConfig ToConfig() {
-      var config = new ItemBoxTrackerConfig();
-      config.Always = always.ToConfig();
-      config.Village = village.ToConfig();
-      config.Quest = quest.ToConfig();
-      return config;
+      return new ItemBoxTrackerConfig {
+        Always = always.ToConfig(),
+        Village = village.ToConfig(),
+        Quest = quest.ToConfig()
+      };
     }
   }
 }

--- a/ItemBoxTracker/ViewModels/ItemViewModel.cs
+++ b/ItemBoxTracker/ViewModels/ItemViewModel.cs
@@ -30,6 +30,18 @@ namespace MHWItemBoxTracker.ViewModels {
       set => SetField(ref amount, value);
     }
 
+    public override bool Equals(object obj) {
+      if ((obj != null) && GetType().Equals(obj.GetType())) {
+        var Obj = (ItemViewModel)obj;
+        return Obj.ItemId == ItemId;
+      }
+      return false;
+    }
+
+    public override int GetHashCode() {
+      return ItemId;
+    }
+
     public ItemConfig ToConfig() {
       return new ItemConfig {
         Name = name,

--- a/ItemBoxTracker/ViewModels/ItemViewModel.cs
+++ b/ItemBoxTracker/ViewModels/ItemViewModel.cs
@@ -10,6 +10,8 @@ namespace MHWItemBoxTracker.ViewModels
     private int itemId;
     private int amount;
 
+    public ItemViewModel() {}
+    
     public ItemViewModel(ItemConfig config) {
       name = config.Name;
       itemId = config.ItemId;

--- a/ItemBoxTracker/ViewModels/ItemViewModel.cs
+++ b/ItemBoxTracker/ViewModels/ItemViewModel.cs
@@ -1,17 +1,14 @@
-﻿using System.ComponentModel.DataAnnotations;
-using MHWItemBoxTracker.Config;
+﻿using MHWItemBoxTracker.Config;
 using MHWItemBoxTracker.Utils;
 
-namespace MHWItemBoxTracker.ViewModels
-{
-  public class ItemViewModel : NotifyPropertyChanged
-  {
+namespace MHWItemBoxTracker.ViewModels {
+  public class ItemViewModel : NotifyPropertyChanged {
     private string name;
     private int itemId;
     private int amount;
 
-    public ItemViewModel() {}
-    
+    public ItemViewModel() { }
+
     public ItemViewModel(ItemConfig config) {
       name = config.Name;
       itemId = config.ItemId;
@@ -34,11 +31,11 @@ namespace MHWItemBoxTracker.ViewModels
     }
 
     public ItemConfig ToConfig() {
-      var config = new ItemConfig();
-      config.Name = name;
-      config.ItemId = itemId;
-      config.Amount = amount;
-      return config;
+      return new ItemConfig {
+        Name = name,
+        ItemId = itemId,
+        Amount = amount
+      };
     }
   }
 }

--- a/ItemBoxTracker/ViewModels/ItemViewModel.cs
+++ b/ItemBoxTracker/ViewModels/ItemViewModel.cs
@@ -1,0 +1,42 @@
+﻿using System.ComponentModel.DataAnnotations;
+using MHWItemBoxTracker.Config;
+using MHWItemBoxTracker.Utils;
+
+namespace MHWItemBoxTracker.ViewModels
+{
+  public class ItemViewModel : NotifyPropertyChanged
+  {
+    private string name;
+    private int itemId;
+    private int amount;
+
+    public ItemViewModel(ItemConfig config) {
+      name = config.Name;
+      itemId = config.ItemId;
+      amount = config.Amount;
+    }
+
+    public string Name {
+      get => name;
+      set => SetField(ref name, value);
+    }
+
+    public int ItemId {
+      get => itemId;
+      set => SetField(ref itemId, value);
+    }
+
+    public int Amount {
+      get => amount;
+      set => SetField(ref amount, value);
+    }
+
+    public ItemConfig ToConfig() {
+      var config = new ItemConfig();
+      config.Name = name;
+      config.ItemId = itemId;
+      config.Amount = amount;
+      return config;
+    }
+  }
+}

--- a/ItemBoxTracker/ViewModels/TrackingTabViewModel.cs
+++ b/ItemBoxTracker/ViewModels/TrackingTabViewModel.cs
@@ -24,6 +24,10 @@ namespace MHWItemBoxTracker.ViewModels
               .Select(i => new ItemViewModel(i))
               .ToList()
         );
+      
+      if (tracking.Count == 0) {
+        tracking.Add(new ItemViewModel());
+      }
     }
 
     public bool TrackPouch {

--- a/ItemBoxTracker/ViewModels/TrackingTabViewModel.cs
+++ b/ItemBoxTracker/ViewModels/TrackingTabViewModel.cs
@@ -9,6 +9,7 @@ namespace MHWItemBoxTracker.ViewModels {
     private bool trackBox;
     private bool trackCraftable;
     private ObservableCollection<ItemViewModel> tracking;
+    private ObservableCollection<ItemViewModel> items;
 
     public TrackingTabViewModel(TrackingTabConfig config) {
       trackPouch = config.TrackPouch;
@@ -43,6 +44,11 @@ namespace MHWItemBoxTracker.ViewModels {
     public ObservableCollection<ItemViewModel> Tracking {
       get => tracking;
       set => SetField(ref tracking, value);
+    }
+
+    public ObservableCollection<ItemViewModel> Items {
+      get => items;
+      set => SetField(ref items, value);
     }
 
     public TrackingTabConfig ToConfig() {

--- a/ItemBoxTracker/ViewModels/TrackingTabViewModel.cs
+++ b/ItemBoxTracker/ViewModels/TrackingTabViewModel.cs
@@ -1,15 +1,10 @@
 ﻿using System.Collections.ObjectModel;
-using System.ComponentModel;
-using System.ComponentModel.DataAnnotations;
 using System.Linq;
-using HunterPie.Plugins;
 using MHWItemBoxTracker.Config;
 using MHWItemBoxTracker.Utils;
 
-namespace MHWItemBoxTracker.ViewModels
-{
-  public class TrackingTabViewModel : NotifyPropertyChanged
-  {
+namespace MHWItemBoxTracker.ViewModels {
+  public class TrackingTabViewModel : NotifyPropertyChanged {
     private bool trackPouch;
     private bool trackBox;
     private bool trackCraftable;
@@ -24,7 +19,7 @@ namespace MHWItemBoxTracker.ViewModels
               .Select(i => new ItemViewModel(i))
               .ToList()
         );
-      
+
       if (tracking.Count == 0) {
         tracking.Add(new ItemViewModel());
       }
@@ -34,12 +29,12 @@ namespace MHWItemBoxTracker.ViewModels
       get => trackPouch;
       set => SetField(ref trackPouch, value);
     }
-    
+
     public bool TrackBox {
       get => trackBox;
       set => SetField(ref trackBox, value);
     }
-    
+
     public bool TrackCraftable {
       get => trackCraftable;
       set => SetField(ref trackCraftable, value);
@@ -51,12 +46,14 @@ namespace MHWItemBoxTracker.ViewModels
     }
 
     public TrackingTabConfig ToConfig() {
-      var config = new TrackingTabConfig();
-      config.TrackPouch = trackPouch;
-      config.TrackBox = trackBox;
-      config.TrackCraftable = trackCraftable;
-      config.Tracking = tracking.Select(i => i.ToConfig()).ToList();
-      return config;
+      return new TrackingTabConfig {
+        TrackPouch = trackPouch,
+        TrackBox = trackBox,
+        TrackCraftable = trackCraftable,
+        Tracking = tracking.Select(i => i.ToConfig())
+                           .Where(i => i.ItemId > 0)
+                           .ToList()
+      };
     }
   }
 }

--- a/ItemBoxTracker/ViewModels/TrackingTabViewModel.cs
+++ b/ItemBoxTracker/ViewModels/TrackingTabViewModel.cs
@@ -1,0 +1,58 @@
+﻿using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using HunterPie.Plugins;
+using MHWItemBoxTracker.Config;
+using MHWItemBoxTracker.Utils;
+
+namespace MHWItemBoxTracker.ViewModels
+{
+  public class TrackingTabViewModel : NotifyPropertyChanged
+  {
+    private bool trackPouch;
+    private bool trackBox;
+    private bool trackCraftable;
+    private ObservableCollection<ItemViewModel> tracking;
+
+    public TrackingTabViewModel(TrackingTabConfig config) {
+      trackPouch = config.TrackPouch;
+      trackBox = config.TrackBox;
+      trackCraftable = config.TrackCraftable;
+      tracking = new ObservableCollection<ItemViewModel>(
+        config.Tracking
+              .Select(i => new ItemViewModel(i))
+              .ToList()
+        );
+    }
+
+    public bool TrackPouch {
+      get => trackPouch;
+      set => SetField(ref trackPouch, value);
+    }
+    
+    public bool TrackBox {
+      get => trackBox;
+      set => SetField(ref trackBox, value);
+    }
+    
+    public bool TrackCraftable {
+      get => trackCraftable;
+      set => SetField(ref trackCraftable, value);
+    }
+
+    public ObservableCollection<ItemViewModel> Tracking {
+      get => tracking;
+      set => SetField(ref tracking, value);
+    }
+
+    public TrackingTabConfig ToConfig() {
+      var config = new TrackingTabConfig();
+      config.TrackPouch = trackPouch;
+      config.TrackBox = trackBox;
+      config.TrackCraftable = trackCraftable;
+      config.Tracking = tracking.Select(i => i.ToConfig()).ToList();
+      return config;
+    }
+  }
+}

--- a/omnisharp.json
+++ b/omnisharp.json
@@ -1,0 +1,16 @@
+{
+  "FormattingOptions": {
+    "NewLinesForBracesInTypes": false,
+    "NewLinesForBracesInMethods": false,
+    "NewLinesForBracesInProperties": false,
+    "NewLinesForBracesInAccessors": false,
+    "NewLinesForBracesInAnonymousMethods": false,
+    "NewLinesForBracesInControlBlocks": false,
+    "NewLinesForBracesInAnonymousTypes": false,
+    "NewLinesForBracesInObjectCollectionArrayInitializers": false,
+    "NewLinesForBracesInLambdaExpressionBody": false,
+    "NewLineForElse": false,
+    "NewLineForCatch": false,
+    "NewLineForFinally": false
+  }
+}

--- a/scripts/gen-module-json.csx
+++ b/scripts/gen-module-json.csx
@@ -6,7 +6,7 @@ using System.IO;
 using System.Security.Cryptography;
 
 using HunterPie.Plugins;
-using MHWItemBoxTracker;
+using MHWItemBoxTracker.Service;
 using Newtonsoft.Json;
 
 var configuration = "Debug";
@@ -25,7 +25,7 @@ info.Name = "ItemBoxTracker";
 info.EntryPoint = "Main.cs";
 info.Description = "A HunterPie plugin to track items the player is farming";
 info.Author = "Stuff";
-info.Version = typeof(Main).Assembly.GetName().Version.ToString();
+info.Version = typeof(ConfigService).Assembly.GetName().Version.ToString();
 info.ReleaseDate = DateTime.Now;
 // info.Links = [{"name": "Homepage", "url": "..."}, {"name": "Changelog", "url": "..."}];
 
@@ -50,7 +50,7 @@ using (var sha = SHA256.Create()) {
     hashes.Add(file, hash);
   }
 }
-hashes.Add(Main.settings, "InstallOnly");
+hashes.Add(ConfigService.settings, "InstallOnly");
 
-var json = JsonConvert.SerializeObject(info, Newtonsoft.Json.Formatting.Indented);
+var json = JsonConvert.SerializeObject(info, Formatting.Indented);
 File.WriteAllText($"{releaseDirectory}/module.json", json);

--- a/scripts/gen-module-json.csx
+++ b/scripts/gen-module-json.csx
@@ -6,11 +6,11 @@ using System.IO;
 using System.Security.Cryptography;
 
 using HunterPie.Plugins;
-using MHWItemBoxTracker.GUI;
+using MHWItemBoxTracker;
 using Newtonsoft.Json;
 
 var configuration = "Debug";
-if(Args.Count > 0) {
+if (Args.Count > 0) {
   configuration = Args[0];
 }
 
@@ -25,7 +25,7 @@ info.Name = "ItemBoxTracker";
 info.EntryPoint = "Main.cs";
 info.Description = "A HunterPie plugin to track items the player is farming";
 info.Author = "Stuff";
-info.Version = typeof(Settings).Assembly.GetName().Version.ToString();
+info.Version = typeof(Main).Assembly.GetName().Version.ToString();
 info.ReleaseDate = DateTime.Now;
 // info.Links = [{"name": "Homepage", "url": "..."}, {"name": "Changelog", "url": "..."}];
 
@@ -38,19 +38,19 @@ update.UpdateUrl = "https://github.com/Stuff-Mods/MHWItemBoxTracker/releases/lat
 var hashes = new Dictionary<string, string>();
 update.FileHashes = hashes;
 
-using (var sha = SHA256.Create()){
-    foreach (string file in files) {
-        var stream = File.Open($"{releaseDirectory}/{file}", FileMode.Open);
-        stream.Position = 0;
+using (var sha = SHA256.Create()) {
+  foreach (string file in files) {
+    var stream = File.Open($"{releaseDirectory}/{file}", FileMode.Open);
+    stream.Position = 0;
 
-        var hashBytes = sha.ComputeHash(stream);
-        stream.Close();
+    var hashBytes = sha.ComputeHash(stream);
+    stream.Close();
 
-        var hash = BitConverter.ToString(hashBytes).Replace("-", "").ToLower();
-        hashes.Add(file, hash);
-    }
+    var hash = BitConverter.ToString(hashBytes).Replace("-", "").ToLower();
+    hashes.Add(file, hash);
+  }
 }
-hashes.Add(Settings.fileName, "InstallOnly");
+hashes.Add(Main.settings, "InstallOnly");
 
 var json = JsonConvert.SerializeObject(info, Newtonsoft.Json.Formatting.Indented);
 File.WriteAllText($"{releaseDirectory}/module.json", json);

--- a/scripts/gen-settings-json.csx
+++ b/scripts/gen-settings-json.csx
@@ -2,13 +2,13 @@
 
 using System.IO;
 
-using MHWItemBoxTracker.GUI;
+using MHWItemBoxTracker;
 using MHWItemBoxTracker.Config;
 using Newtonsoft.Json;
 
 // TODO: D.R.Y.
 var configuration = "Debug";
-if(Args.Count > 0) {
+if (Args.Count > 0) {
   configuration = Args[0];
 }
 
@@ -16,4 +16,4 @@ var releaseDirectory = $"ItemBoxTracker/bin/{configuration}";
 
 var settings = new ItemBoxTrackerConfig();
 var json = JsonConvert.SerializeObject(settings, Newtonsoft.Json.Formatting.Indented);
-File.WriteAllText($"{releaseDirectory}/{Settings.fileName}", json);
+File.WriteAllText($"{releaseDirectory}/{Main.settings}", json);

--- a/scripts/gen-settings-json.csx
+++ b/scripts/gen-settings-json.csx
@@ -1,9 +1,8 @@
 #r "ItemBoxTracker.dll"
 
 using System.IO;
-
-using MHWItemBoxTracker;
 using MHWItemBoxTracker.Config;
+using MHWItemBoxTracker.Service;
 using Newtonsoft.Json;
 
 // TODO: D.R.Y.
@@ -15,5 +14,5 @@ if (Args.Count > 0) {
 var releaseDirectory = $"ItemBoxTracker/bin/{configuration}";
 
 var settings = new ItemBoxTrackerConfig();
-var json = JsonConvert.SerializeObject(settings, Newtonsoft.Json.Formatting.Indented);
-File.WriteAllText($"{releaseDirectory}/{Main.settings}", json);
+var json = JsonConvert.SerializeObject(settings, Formatting.Indented);
+File.WriteAllText($"{releaseDirectory}/{ConfigService.settings}", json);


### PR DESCRIPTION
# Feature

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] ~~Tests for the changes have been added (for bug fixes / features)~~
<!-- - [ ] Pre-commmit hook is enabled (`git config --get core.hooksPath` is _.githooks_) -->
- [x] ~~Docs have been reviewed and added / updated if needed (for bug fixes / features)~~

## What does this implement/fix? Explain your changes.

This PR adds a settings screen that supports the config shipped in PR #54 ([v0.3.0](https://github.com/Stuff-Mods/MHWItemBoxTracker/releases/tag/v0.3.0) aka v1.0.0).
It is only the settings screen. The switches don't really do anything, and only the *Always* tab is used (should've been *Village*).
The behavior is otherwise unchanged. The GUI pops up in the village as if you configured the *Village* tab (my mistake) and behaves as if you only enabled **Track items in box**.

## Is this related to any currently open issues?

 - Closes #27

## What tests cover this change?

Sorry, guys. I tested it by looking really hard instead of writing tests. 🤣 

## Other information

![itemboxtracker](https://user-images.githubusercontent.com/5027713/117398871-3f645200-aecd-11eb-8390-a14594aab54e.gif)

I used Xbox Game bar to capture this, and I guess it can't show the popups... Here are screenshots of what it missed:

![image](https://user-images.githubusercontent.com/5027713/117398995-818d9380-aecd-11eb-8e79-526602b95a91.png)

![image](https://user-images.githubusercontent.com/5027713/117399014-8ce0bf00-aecd-11eb-83b0-dfbfe7c78853.png)

The WIP disclaimer is there to inform users that configuring the new settings don't do anything, but once features are rolled out, the settings will be meaningful, so they can make configuration changes while they wait. ¯\\\_(ツ)\_/¯

Although this is about PR #54, I think it's easier to show the effects of that change after seeing the settings screen in action...

### Before

```json
{
    "Tracking": [
        {
            "Name": "Potion",
            "ItemId": 1,
            "Amount": 999
        }
    ]
}
```

### After

```json
{
  "Always": {
    "TrackPouch": false,
    "TrackBox": true,
    "TrackCraftable": false,
    "Tracking": [
      {
        "Name": "Potion",
        "ItemId": 1,
        "Amount": 999
      },
      {
        "Name": "Red Orb",
        "ItemId": 934,
        "Amount": 19
      }
    ]
  },
  "Village": {
    "TrackPouch": false,
    "TrackBox": true,
    "TrackCraftable": false,
    "Tracking": []
  },
  "Quest": {
    "TrackPouch": false,
    "TrackBox": true,
    "TrackCraftable": false,
    "Tracking": []
  }
}


```