### PR TITLE
fix(settings): fix NullReferenceException caused by game not launched

### DIFF
--- a/ItemBoxTracker/Converter/CountToString.cs
+++ b/ItemBoxTracker/Converter/CountToString.cs
@@ -1,0 +1,11 @@
+using HunterPie.UI.Infrastructure.Converters;
+
+namespace MHWItemBoxTracker.Converter {
+  public class CountToString : GenericValueConverter<int, string> {
+    public string Zero { get; set; }
+    public string More { get; set; }
+    public override string Convert(int value, object _) {
+      return value > 0 ? More : Zero;
+    }
+  }
+}

--- a/ItemBoxTracker/GUI/AutoSuggestBox.xaml
+++ b/ItemBoxTracker/GUI/AutoSuggestBox.xaml
@@ -100,7 +100,7 @@
     <Popup
         x:Name="suggestionsPopup"
         Visibility="{Binding IsOpen, ElementName=suggestionsPopup, Converter={convert:BooleanToVisibilityConverter}}"
-        MinWidth="{Binding ActualWidth}"
+        Width="{Binding ActualWidth}"
         MinHeight="30"
         MaxHeight="150"
         StaysOpen="False"
@@ -114,8 +114,9 @@
 
         <TextBlock
             x:Name="noResults"
+            TextWrapping="Wrap"
             Background="{x:Null}"
-            Text="No results..."
+            Text="{Binding NoResultsText}"
             VerticalAlignment="Center"
             Padding="5 0"
             Foreground="#ffbfbfbf" />

--- a/ItemBoxTracker/GUI/AutoSuggestBox.xaml.cs
+++ b/ItemBoxTracker/GUI/AutoSuggestBox.xaml.cs
@@ -68,6 +68,18 @@ namespace MHWItemBoxTracker.GUI {
       get { return (string)GetValue(PlaceholderProperty); }
       set { SetValue(PlaceholderProperty, value); }
     }
+
+    public static readonly DependencyProperty NoResultsProperty = DependencyProperty.Register(
+    "NoResultsText", typeof(string), typeof(AutoSuggestBox), new PropertyMetadata("No Results..."));
+    /// <value>
+    /// DependencyProperty <c>NoResultsText</c>
+    /// is the text to show when there are no results.
+    /// Defaults to "No Results..."
+    /// </value>
+    public string NoResultsText {
+      get { return (string)GetValue(NoResultsProperty); }
+      set { SetValue(NoResultsProperty, value); }
+    }
     public static readonly DependencyProperty SelectionProperty = DependencyProperty.Register(
     "Selection", typeof(object), typeof(AutoSuggestBox), new PropertyMetadata(null));
     /// <value>

--- a/ItemBoxTracker/GUI/ItemDataTemplate.xaml
+++ b/ItemBoxTracker/GUI/ItemDataTemplate.xaml
@@ -15,7 +15,6 @@
               Padding="5 5"
               TextWrapping="Wrap"
               Text="{Binding ItemId, Converter={convert:ItemIdToDescription}}" />
-          <!-- <TextBlock Foreground="#ffbfbfbf" Text="{Binding ItemId, Converter={StaticResource dec2hex}}" /> -->
         </StackPanel>
       </StackPanel.ToolTip>
 

--- a/ItemBoxTracker/GUI/Settings.xaml.cs
+++ b/ItemBoxTracker/GUI/Settings.xaml.cs
@@ -40,18 +40,20 @@ namespace MHWItemBoxTracker.GUI {
     }
 
     private void LoadItems() {
-      var items = new ObservableCollection<ItemViewModel>(Enumerable
-        .Range(0, GMD.Items.gValuesOffsets.Length / 2)
-        .Select(id => new ItemViewModel {
-          ItemId = id,
-          Name = GMD.GetItemNameById(id)
-        })
-        .Where(item => item.Name != null)
-        .ToList());
+      if (GMD.Items.gValuesOffsets != null) {
+        var items = new ObservableCollection<ItemViewModel>(Enumerable
+          .Range(0, GMD.Items.gValuesOffsets.Length / 2)
+          .Select(id => new ItemViewModel {
+            ItemId = id,
+            Name = GMD.GetItemNameById(id)
+          })
+          .Where(item => item.Name != null)
+          .ToList());
 
-      vm.Items.Clear();
-      foreach (var item in items) {
-        vm.Items.Add(item);
+        vm.Items.Clear();
+        foreach (var item in items) {
+          vm.Items.Add(item);
+        }
       }
     }
   }

--- a/ItemBoxTracker/GUI/SettingsTab.xaml
+++ b/ItemBoxTracker/GUI/SettingsTab.xaml
@@ -4,6 +4,7 @@
     xmlns:vm="clr-namespace:MHWItemBoxTracker.ViewModels"
     xmlns:src="clr-namespace:HunterPie.GUI;assembly=HunterPie.UI"
     xmlns:Custom="clr-namespace:HunterPie.GUIControls.Custom_Controls;assembly=HunterPie.UI"
+    xmlns:convert="clr-namespace:MHWItemBoxTracker.Converter"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -20,7 +21,7 @@
     </ResourceDictionary>
   </UserControl.Resources>
 
-  <StackPanel>
+  <StackPanel x:Name="settingsTab">
 
 
     <Grid HorizontalAlignment="Center">
@@ -94,6 +95,7 @@
                         Content="▼" />
                     <local:AutoSuggestBox
                         Placeholder="Search items..."
+                        NoResultsText="{Binding DataContext.Items.Count, RelativeSource={RelativeSource AncestorType=UserControl}, Converter={convert:CountToString Zero=Please launch the game to enable this search and then reload this screen once HunterPie has loaded the strings, More=No Results...}}"
                         Selection="{Binding DataContext, RelativeSource={RelativeSource AncestorType=StackPanel}, Mode=TwoWay}"
                         ItemTemplate="{StaticResource ItemDataTemplate}"
                         OnTextChanged="OnTextChanged"

--- a/ItemBoxTracker/ItemBoxTracker.csproj
+++ b/ItemBoxTracker/ItemBoxTracker.csproj
@@ -135,6 +135,7 @@
 
     <Compile Include="Controller\ItemBoxTracker.cs" />
 
+    <Compile Include="Converter\CountToString.cs" />
     <Compile Include="Converter\ItemIdToDescription.cs" />
 
     <Compile Include="Service\ConfigService.cs" />


### PR DESCRIPTION
# Bugfix

## Pull request checklist

<!-- Checkboxes can be checked like this: [x] -->

Please check if your PR fulfills the following requirements:
- [ ] ~~Tests for the changes have been added (for bug fixes / features)~~
<!-- - [ ] Pre-commmit hook is enabled (`git config --get core.hooksPath` is _.githooks_) -->
- [x] ~~Docs have been reviewed and added / updated if needed (for bug fixes / features)~~

## What does this implement/fix? Explain your changes.
If the game is not loaded, `GMD.Items.gValuesOffsets` is null. Trying to get it's length, of course throws NRE. To inform the user of the reason they can't search, I've also added a message to the no results box.

## Is this related to any currently open issues?
Didn't open an issue to track this...

## What tests cover this change?
Clicking around...

## Other information
![image](https://user-images.githubusercontent.com/5027713/117563439-de2ab300-b073-11eb-99f4-759247065d84.png)
