### PR TITLE
merge: track craftable items

### DIFF
--- a/ItemBoxTracker/src/Plugin/GUI/InventoryItemDataTemplate.xaml
+++ b/ItemBoxTracker/src/Plugin/GUI/InventoryItemDataTemplate.xaml
@@ -23,7 +23,7 @@
             Padding="0,0,10,0" />
         <Grid.ColumnDefinitions>
           <ColumnDefinition Width="*" />
-          <ColumnDefinition Width="75" />
+          <ColumnDefinition Width="125" />
         </Grid.ColumnDefinitions>
       </Grid>
       <ContentControl Content="{Binding Path=., Converter={convert:InventoryToAmounts}}" />

--- a/README.md
+++ b/README.md
@@ -4,9 +4,12 @@ A plugin for hunter pie that lets players track the items they are farming.
 
 Reducing cognitive overhead by allowing the player to stop looking at the box after every quest to find out that they still need 5 more tickets, 1 less than the last time they checked, and stop asking "how many did I need again?"
 
-![Overlay](https://user-images.githubusercontent.com/5027713/118384904-3b74b600-b5d8-11eb-90d7-5b6794b67526.png)
+![Overlay](https://user-images.githubusercontent.com/5027713/118386273-4df4ec80-b5e4-11eb-9a6b-7c1e4c2f9fa2.png)
+
 
 > The numbers displayed are `pouch | box (+craftable) / wanted`
+> 
+> Craftable items are counted from box items if **Track items in box** is enabled and from pouch if **Track items in pouch** is enabled. The number shown is their sum.
 
 ## Changelog
 


### PR DESCRIPTION
# Feature

## Pull request checklist

<!-- Checkboxes can be checked like this: [x] -->

Please check if your PR fulfills the following requirements:
- [ ] ~~Tests for the changes have been added (for bug fixes / features)~~
<!-- - [ ] Pre-commmit hook is enabled (`git config --get core.hooksPath` is _.githooks_) -->
- [x] ~~Docs have been reviewed and added / updated if needed (for bug fixes / features)~~

## What does this implement/fix? Explain your changes.

Implements tracking craftable items. Counts combos in pouch if pouch tracking is enabled, and combos in box if box tracking is enabled. The widget displays the sum of these.

## Is this related to any currently open issues?

 - Closes #24 

## What tests cover this change?

None...

## Other information

![image](https://user-images.githubusercontent.com/5027713/118386187-a5df2380-b5e3-11eb-8dad-ec074711db72.png)
